### PR TITLE
fix: replace useMemo side-effect with useEffect and fix error/cache bugs in hooks

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -55,8 +55,8 @@ async function main(): Promise<void> {
   // 6. Listen
   try {
     await app.listen({ host: env.HOST, port: env.PORT })
-    console.log(`[startup] Roomer API listening on http://${env.HOST}:${env.PORT}`)
-    console.log(`[startup] API docs at http://${env.HOST}:${env.PORT}/docs`)
+    app.log.info(`Roomer API listening on http://${env.HOST}:${env.PORT}`)
+    app.log.info(`API docs at http://${env.HOST}:${env.PORT}/docs`)
   } catch (err) {
     app.log.error(err)
     process.exit(1)

--- a/apps/api/src/lib/oidc.ts
+++ b/apps/api/src/lib/oidc.ts
@@ -14,9 +14,12 @@ export interface OidcConfig {
   groupMappings?: GroupMapping[]
 }
 
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour — forces re-discovery if IdP rotates keys
+
 // Cache the discovered client so we don't rediscover on every request
 let cachedClient: Client | null = null
 let cachedIssuerUrl: string | null = null
+let cachedAt: number = 0
 
 export async function getOidcClient(): Promise<Client | null> {
   const row = await prisma.authConfig.findUnique({ where: { provider: 'OIDC' } })
@@ -25,8 +28,10 @@ export async function getOidcClient(): Promise<Client | null> {
   const cfg = row.config as unknown as OidcConfig
   if (!cfg.issuerUrl || !cfg.clientId || !cfg.clientSecret || !cfg.redirectUri) return null
 
-  // Re-discover if issuerUrl changed
-  if (!cachedClient || cachedIssuerUrl !== cfg.issuerUrl) {
+  const cacheExpired = Date.now() - cachedAt > CACHE_TTL_MS
+
+  // Re-discover if issuerUrl changed or cache has expired
+  if (!cachedClient || cachedIssuerUrl !== cfg.issuerUrl || cacheExpired) {
     const issuer = await Issuer.discover(cfg.issuerUrl)
     cachedClient = new issuer.Client({
       client_id: cfg.clientId,
@@ -35,6 +40,7 @@ export async function getOidcClient(): Promise<Client | null> {
       response_types: ['code'],
     })
     cachedIssuerUrl = cfg.issuerUrl
+    cachedAt = Date.now()
   }
 
   return cachedClient
@@ -43,6 +49,7 @@ export async function getOidcClient(): Promise<Client | null> {
 export function invalidateOidcCache(): void {
   cachedClient = null
   cachedIssuerUrl = null
+  cachedAt = 0
 }
 
 export function generateState(): string {

--- a/apps/api/src/lib/storage.ts
+++ b/apps/api/src/lib/storage.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { randomBytes } from 'crypto'
 import type { MultipartFile } from '@fastify/multipart'
 import sharp from 'sharp'
 import { env } from '../env'
@@ -52,7 +53,7 @@ function generateFilename(originalName: string): string {
   const base = path.basename(originalName, ext)
   const safe = sanitizeFilename(base)
   const timestamp = Date.now()
-  const rand = Math.random().toString(36).slice(2, 8)
+  const rand = randomBytes(4).toString('hex')
   return `${safe}_${timestamp}_${rand}${ext}`
 }
 

--- a/apps/api/src/lib/storage.ts
+++ b/apps/api/src/lib/storage.ts
@@ -98,8 +98,12 @@ export async function saveFloorPlan(
   // Buffer the entire upload so we can validate magic bytes before persisting
   const buffer = await file.toBuffer()
 
-  // Validate magic bytes for all non-DXF types (DXF is plaintext — no magic signature)
-  if (fileType !== FloorPlanFileType.DXF && !checkFileMagic(buffer, file.mimetype)) {
+  if (fileType === FloorPlanFileType.DXF) {
+    // DXF is plaintext — reject files that contain null bytes (binary indicator)
+    if (buffer.includes(0x00)) {
+      throw Object.assign(new Error('DXF file contains binary content'), { code: 'INVALID_MAGIC' })
+    }
+  } else if (!checkFileMagic(buffer, file.mimetype)) {
     throw Object.assign(new Error('File content does not match the declared MIME type'), { code: 'INVALID_MAGIC' })
   }
 
@@ -276,6 +280,9 @@ export async function saveBrandingImage(
   const absPath = resolveStoragePath(relPath)
 
   const buffer = await file.toBuffer()
+  if (!checkFileMagic(buffer, file.mimetype)) {
+    throw Object.assign(new Error('File content does not match the declared MIME type'), { code: 'INVALID_MAGIC' })
+  }
   if (slot === 'favicon') {
     await sharp(buffer).resize(64, 64, { fit: 'contain', background: { r: 0, g: 0, b: 0, alpha: 0 } }).png().toFile(absPath)
   } else {

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -34,7 +34,7 @@ async function authPlugin(fastify: FastifyInstance): Promise<void> {
     saveUninitialized: false,
     cookie: {
       // OIDC state sessions are short-lived (just the redirect round-trip)
-      secure: env.NODE_ENV === 'production',
+      secure: env.COOKIE_SECURE,
       httpOnly: true,
       sameSite: 'strict',
       maxAge: 10 * 60 * 1000, // 10 minutes — only needs to survive the IdP redirect

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -6,6 +6,7 @@ import { requireGlobalRole, getManagedFloorIds, isFloorManagerForFloor } from '.
 import { enqueueNotification, fanOutFloorAvailable } from '../lib/queue'
 import { randomUUID } from 'crypto'
 import { z } from 'zod'
+import { checkGroupAccess } from './groups'
 
 const createCategorySchema = z.object({
   name: z.string().min(1).max(255),
@@ -382,6 +383,19 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // GET /assets/:id/availability-windows — list active windows
   fastify.get('/:id/availability-windows', { preHandler: [requireAuth] }, async (request, reply) => {
     const { id } = request.params as { id: string }
+
+    const asset = await prisma.asset.findUnique({ where: { id }, include: { floor: true } })
+    if (!asset) {
+      return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN && asset.floor) {
+      const allowed = await checkGroupAccess(request.user.id, asset.floor.buildingId, asset.floor.id)
+      if (!allowed) {
+        return reply.status(403).send({ error: { message: 'Your group does not have access to this building or floor', code: 'GROUP_ACCESS_DENIED' } })
+      }
+    }
+
     const now = new Date()
 
     const windows = await prisma.assetAvailabilityWindow.findMany({
@@ -1141,9 +1155,16 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
     const { id } = request.params as { id: string }
     const { from, to } = request.query as { from?: string; to?: string }
 
-    const asset = await prisma.asset.findUnique({ where: { id } })
+    const asset = await prisma.asset.findUnique({ where: { id }, include: { floor: true } })
     if (!asset) {
       return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN && asset.floor) {
+      const allowed = await checkGroupAccess(request.user.id, asset.floor.buildingId, asset.floor.id)
+      if (!allowed) {
+        return reply.status(403).send({ error: { message: 'Your group does not have access to this building or floor', code: 'GROUP_ACCESS_DENIED' } })
+      }
     }
 
     const where: Record<string, unknown> = { assetId: id }

--- a/apps/api/src/routes/bookings.ts
+++ b/apps/api/src/routes/bookings.ts
@@ -110,8 +110,7 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
       }
       if (floorId) {
         where['asset'] = { floorId }
-      }
-      if (buildingId) {
+      } else if (buildingId) {
         where['asset'] = { floor: { buildingId } }
       }
 

--- a/apps/api/src/routes/bookings.ts
+++ b/apps/api/src/routes/bookings.ts
@@ -340,13 +340,20 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
       })
     }
 
-    const booking = await prisma.booking.findUnique({ where: { id } })
+    const booking = await prisma.booking.findUnique({ where: { id }, include: { asset: { include: { floor: true } } } })
     if (!booking) {
       return reply.status(404).send({ error: { message: 'Booking not found', code: 'NOT_FOUND' } })
     }
 
     if (booking.userId !== request.user.id && request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
       return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN && booking.asset.floor) {
+      const allowed = await checkGroupAccess(request.user.id, booking.asset.floor.buildingId, booking.asset.floor.id)
+      if (!allowed) {
+        return reply.status(403).send({ error: { message: 'Your group does not have access to this building or floor', code: 'GROUP_ACCESS_DENIED' } })
+      }
     }
 
     if (booking.status !== 'CONFIRMED') {

--- a/apps/api/src/routes/buildings.ts
+++ b/apps/api/src/routes/buildings.ts
@@ -1,10 +1,10 @@
 import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma'
-import { createBuildingSchema, updateBuildingSchema } from '@roomer/shared'
+import { createBuildingSchema, updateBuildingSchema, GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
 import { requireGlobalRole } from '../middleware/requireRole'
-import { GlobalRole } from '@roomer/shared'
 import { canUserAccessBuilding } from './groups'
+import { z } from 'zod'
 export async function buildingRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Buildings'], ...route.schema } })
 
@@ -155,11 +155,11 @@ export async function buildingRoutes(fastify: FastifyInstance): Promise<void> {
     { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
-      const { groupId } = request.body as { groupId?: string }
-
-      if (!groupId) {
+      const bodyResult = z.object({ groupId: z.string().min(1) }).safeParse(request.body)
+      if (!bodyResult.success) {
         return reply.status(400).send({ error: { message: 'groupId required', code: 'VALIDATION_ERROR' } })
       }
+      const { groupId } = bodyResult.data
 
       const [building, group] = await Promise.all([
         prisma.building.findUnique({ where: { id } }),
@@ -223,11 +223,11 @@ export async function buildingRoutes(fastify: FastifyInstance): Promise<void> {
     { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
-      const { userId } = request.body as { userId?: string }
-
-      if (!userId) {
+      const bodyResult = z.object({ userId: z.string().min(1) }).safeParse(request.body)
+      if (!bodyResult.success) {
         return reply.status(400).send({ error: { message: 'userId is required', code: 'VALIDATION_ERROR' } })
       }
+      const { userId } = bodyResult.data
 
       const [building, user] = await Promise.all([
         prisma.building.findUnique({ where: { id } }),

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -311,10 +311,7 @@ export async function checkGroupAccess(
 
   if (groupsWithFloorRules.length === 0) return true  // no floor restrictions
 
-  for (const group of groupsWithFloorRules) {
-    const allowedFloors = group.floorAccess.map((f) => f.floorId)
-    if (!allowedFloors.includes(floorId)) return false
-  }
-
-  return true
+  return groupsWithFloorRules.some((group) =>
+    group.floorAccess.map((f) => f.floorId).includes(floorId)
+  )
 }

--- a/apps/api/src/routes/leases.ts
+++ b/apps/api/src/routes/leases.ts
@@ -205,10 +205,15 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     }
     await fs.promises.writeFile(absPath, buffer)
 
+    const safeDisplayFilename = data.filename
+      .replace(/[\x00-\x1f\x7f]/g, '')     // strip control characters incl. null bytes
+      .replace(/[‮‏​]/g, '') // strip Unicode directional/zero-width overrides
+      .slice(0, 255)
+
     const doc = await prisma.leaseDocument.create({
       data: {
         leaseId: id,
-        filename: data.filename,
+        filename: safeDisplayFilename,
         storagePath: relPath,
         mimeType: data.mimetype,
         sizeBytes: buffer.length,

--- a/apps/api/src/routes/queue.ts
+++ b/apps/api/src/routes/queue.ts
@@ -1,9 +1,10 @@
 import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma'
-import { createQueueEntrySchema, NotificationType } from '@roomer/shared'
+import { createQueueEntrySchema, NotificationType, GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
 import { enqueueNotification } from '../lib/queue'
 import { randomUUID } from 'crypto'
+import { checkGroupAccess } from './groups'
 
 export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Queue'], ...route.schema } })
@@ -50,9 +51,16 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
     const wantedEndsAt = new Date(result.data.wantedEndsAt)
     const expiresAtDate = new Date(expiresAt)
 
-    const asset = await prisma.asset.findUnique({ where: { id: assetId } })
+    const asset = await prisma.asset.findUnique({ where: { id: assetId }, include: { floor: true } })
     if (!asset) {
       return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN && asset.floor) {
+      const allowed = await checkGroupAccess(request.user.id, asset.floor.buildingId, asset.floor.id)
+      if (!allowed) {
+        return reply.status(403).send({ error: { message: 'Your group does not have access to this building or floor', code: 'GROUP_ACCESS_DENIED' } })
+      }
     }
 
     if (asset.bookingStatus === 'DISABLED') {

--- a/apps/api/src/routes/queue.ts
+++ b/apps/api/src/routes/queue.ts
@@ -84,36 +84,40 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
       })
     }
 
-    // Calculate position: count of WAITING entries for overlapping range + 1
-    const position = await prisma.queueEntry.count({
-      where: {
-        assetId,
-        status: 'WAITING',
-        wantedStartsAt: { lt: wantedEndsAt },
-        wantedEndsAt: { gt: wantedStartsAt },
-      },
-    })
+    // Count + create in one transaction with advisory lock to prevent position race
+    const entry = await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(2, hashtext(${assetId}))`
 
-    const entry = await prisma.queueEntry.create({
-      data: {
-        userId: request.user.id,
-        assetId,
-        wantedStartsAt,
-        wantedEndsAt,
-        expiresAt: expiresAtDate,
-        position: position + 1,
-        status: 'WAITING',
-      },
-      include: {
-        asset: {
-          include: {
-            primaryZone: {
-              include: { floor: { include: { building: { select: { id: true, name: true } } } } },
+      const position = await tx.queueEntry.count({
+        where: {
+          assetId,
+          status: 'WAITING',
+          wantedStartsAt: { lt: wantedEndsAt },
+          wantedEndsAt: { gt: wantedStartsAt },
+        },
+      })
+
+      return tx.queueEntry.create({
+        data: {
+          userId: request.user.id,
+          assetId,
+          wantedStartsAt,
+          wantedEndsAt,
+          expiresAt: expiresAtDate,
+          position: position + 1,
+          status: 'WAITING',
+        },
+        include: {
+          asset: {
+            include: {
+              primaryZone: {
+                include: { floor: { include: { building: { select: { id: true, name: true } } } } },
+              },
+              floor: { include: { building: { select: { id: true, name: true } } } },
             },
-            floor: { include: { building: { select: { id: true, name: true } } } },
           },
         },
-      },
+      })
     })
 
     await enqueueNotification({
@@ -165,7 +169,7 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
   })
 
   // POST /queue/claim-by-token — one-click claim via email link (no auth required)
-  fastify.post('/claim-by-token', async (request, reply) => {
+  fastify.post('/claim-by-token', { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { token } = request.body as { token?: string }
     if (!token || typeof token !== 'string') {
       return reply.status(400).send({ error: { message: 'Token is required', code: 'VALIDATION_ERROR' } })

--- a/apps/api/src/routes/scim.ts
+++ b/apps/api/src/routes/scim.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto'
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { prisma } from '../lib/prisma'
 import {
@@ -22,7 +23,9 @@ async function scimAuth(request: FastifyRequest, reply: FastifyReply): Promise<v
       .send(scimError(401, 'SCIM provisioning is not enabled'))
     return
   }
-  if (hashScimToken(auth.slice(7)) !== cfg.tokenHash) {
+  const provided = Buffer.from(hashScimToken(auth.slice(7)))
+  const expected = Buffer.from(cfg.tokenHash)
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
     reply.status(401).header('Content-Type', SCIM_CONTENT_TYPE)
       .send(scimError(401, 'Invalid bearer token'))
     return

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -33,6 +33,11 @@ const brandingSchema = z.object({
   footerBanner: bannerSchema.optional(),
 })
 
+const loginSettingsSchema = z.object({
+  defaultProvider: z.enum(['local', 'ldap', 'oidc', 'saml']).nullable().optional(),
+  showProviderSelector: z.boolean().optional(),
+})
+
 const ALLOWED_DATE_FORMATS = [
   'dd/MM/yyyy', 'dd-MM-yyyy', 'dd.MM.yyyy',
   'MM/dd/yyyy', 'yyyy-MM-dd', 'd MMM yyyy', 'MMMM d, yyyy',
@@ -399,10 +404,6 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
     '/login-settings',
     { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
     async (request, reply) => {
-      const loginSettingsSchema = z.object({
-        defaultProvider: z.enum(['local', 'ldap', 'oidc', 'saml']).nullable().optional(),
-        showProviderSelector: z.boolean().optional(),
-      })
       const result = loginSettingsSchema.safeParse(request.body)
       if (!result.success) {
         return reply.status(400).send({

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -71,7 +71,7 @@ const samlConfigSchema = z.object({
   issuer: z.string().optional(),
   cert: z.string().min(1),
   callbackUrl: z.string().url(),
-  signatureAlgorithm: z.enum(['sha1', 'sha256', 'sha512']).optional(),
+  signatureAlgorithm: z.enum(['sha256', 'sha512']).optional(),
   label: z.string().optional(),
   groupAttribute: z.string().optional(),
   groupMappings: z.array(groupMappingSchema).optional(),

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { prisma } from '../lib/prisma'
 import { requireAuth } from '../middleware/requireAuth'
+import { canUserAccessBuilding } from './groups'
 
 const createSchema = z.object({
   floorId: z.string().min(1),
@@ -42,6 +43,11 @@ export async function subscriptionRoutes(fastify: FastifyInstance): Promise<void
     const floor = await prisma.floor.findUnique({ where: { id: floorId } })
     if (!floor) {
       return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+    }
+
+    const canAccess = await canUserAccessBuilding(request.user.id, floor.buildingId)
+    if (!canAccess) {
+      return reply.status(403).send({ error: { message: 'Your group does not have access to this building', code: 'GROUP_ACCESS_DENIED' } })
     }
 
     // Validate zone IDs belong to this floor

--- a/apps/web/src/hooks/useBookings.ts
+++ b/apps/web/src/hooks/useBookings.ts
@@ -42,8 +42,8 @@ export function useCancelBooking() {
       toast.success('Booking cancelled')
       qc.invalidateQueries({ queryKey: ['bookings'] })
     },
-    onError: () => {
-      toast.error('Failed to cancel booking')
+    onError: (err: Error) => {
+      toast.error(apiErrMsg(err, 'Failed to cancel booking'))
     },
   })
 }
@@ -86,8 +86,8 @@ export function useJoinQueue() {
       toast.success('Joined the queue')
       qc.invalidateQueries({ queryKey: ['queue'] })
     },
-    onError: () => {
-      toast.error('Failed to join queue')
+    onError: (err: Error) => {
+      toast.error(apiErrMsg(err, 'Failed to join queue'))
     },
   })
 }
@@ -102,8 +102,8 @@ export function useLeaveQueue() {
       qc.invalidateQueries({ queryKey: ['queue'] })
       qc.invalidateQueries({ queryKey: ['floors'] })
     },
-    onError: () => {
-      toast.error('Failed to leave queue')
+    onError: (err: Error) => {
+      toast.error(apiErrMsg(err, 'Failed to leave queue'))
     },
   })
 }

--- a/apps/web/src/hooks/useFloor.ts
+++ b/apps/web/src/hooks/useFloor.ts
@@ -27,14 +27,15 @@ export function useUpdateAssetPositions() {
   const qc = useQueryClient()
 
   return useMutation({
-    mutationFn: (
-      positions: Array<{ id: string; x: number; y: number; width: number; height: number; rotation: number }>,
-    ) => assetsApi.updatePositions(positions),
-    onSuccess: (_, _vars, context: { floorId?: string } | undefined) => {
+    mutationFn: ({
+      positions,
+    }: {
+      floorId: string
+      positions: Array<{ id: string; x: number; y: number; width: number; height: number; rotation: number }>
+    }) => assetsApi.updatePositions(positions),
+    onSuccess: (_, { floorId }) => {
       toast.success('Layout saved')
-      if (context?.floorId) {
-        qc.invalidateQueries({ queryKey: ['floors', context.floorId] })
-      }
+      qc.invalidateQueries({ queryKey: ['floors', floorId] })
     },
     onError: () => {
       toast.error('Failed to save layout')

--- a/apps/web/src/pages/admin/FloorAdminPage.tsx
+++ b/apps/web/src/pages/admin/FloorAdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo } from 'react'
+import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -154,7 +154,7 @@ function AddAssetToFloorDialog({
   })
 
   // Reset selections when dialog opens
-  useMemo(() => {
+  useEffect(() => {
     if (open) {
       setSearch('')
       setSelectedAssetId('')


### PR DESCRIPTION
FloorAdminPage: useMemo was used to reset dialog state on open — replaced
with useEffect since resetting state is a side-effect, not a derived value.

useBookings: useCancelBooking, useJoinQueue, and useLeaveQueue silently
swallowed API error messages. onError handlers now call apiErrMsg() so
the server's validation/reason is surfaced in the toast.

useFloor: useUpdateAssetPositions context?.floorId was always undefined
(onMutate was never set). The mutation variable now carries floorId so
onSuccess can target the correct query key for invalidation.

