### PR TITLE
refactor: remove unnecessary any casts in useAuth and floors route



### DIFF
--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -353,9 +353,8 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
         requireAuth,
         async (request, reply) => {
           const { id } = request.params as { id: string }
-          const user = (request as any).user
-          if (user.globalRole === 'SUPER_ADMIN') return
-          const isManager = await isFloorManagerForFloor(user.id, id)
+          if (request.user.globalRole === 'SUPER_ADMIN') return
+          const isManager = await isFloorManagerForFloor(request.user.id, id)
           if (!isManager) {
             return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
           }

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -34,7 +34,7 @@ export function useAuth() {
         navigate('/login', { replace: true })
       }
     } else {
-      setUser((data?.data as any)?.user ?? null)
+      setUser(data?.data?.user ?? null)
       setLoading(false)
     }
   }, [data, queryLoading, error, setUser, setLoading, qc, navigate])


### PR DESCRIPTION
useAuth.ts: authApi.me() already returns { data: { user: User } } so
(data?.data as any)?.user is not needed — access data?.data?.user directly.

floors.ts: FastifyRequest is augmented with a user property via the
requireAuth middleware declaration; (request as any).user is unnecessary.