### PR TITLE
fix(ui): prevent date format refetch on window focus and cache eviction

### DIFF
--- a/apps/web/src/hooks/useDateFormatInit.ts
+++ b/apps/web/src/hooks/useDateFormatInit.ts
@@ -8,7 +8,9 @@ export function useDateFormatInit(): void {
     queryKey: ['settings', 'public'],
     queryFn: () => settingsApi.getPublic(),
     select: (r) => r.data,
-    staleTime: 5 * 60 * 1000,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
   })
 
   useEffect(() => {


### PR DESCRIPTION
The public settings query (which seeds the org's dateFormat) used a
5-minute staleTime meaning it would refetch after each focus, re-applying
the format on every tab switch. Changed to staleTime: Infinity with
gcTime: Infinity and refetchOnWindowFocus: false — org config is
effectively immutable at runtime and needs no background refresh.

