### PR TITLE
refactor: extract parseDateParam and countWorkingDays helpers, deduplicate branding serve

### DIFF
--- a/apps/api/src/lib/jwt.ts
+++ b/apps/api/src/lib/jwt.ts
@@ -17,9 +17,9 @@ export const TOKEN_COOKIE_OPTS = {
   path: '/',
 } as const
 
-/** Lifetime of an access token: 8 hours (one working day). */
-const EXPIRES_IN = '8h'
+/** Lifetime of an access token in seconds: 8 hours (one working day). */
 const MAX_AGE_SECONDS = 8 * 60 * 60
+const EXPIRES_IN = MAX_AGE_SECONDS  // jsonwebtoken accepts seconds as a number
 
 export const TOKEN_MAX_AGE = MAX_AGE_SECONDS
 

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -15,6 +15,9 @@ export function getBoss(): PgBoss {
   return boss
 }
 
+/** How long a promoted queue entry has to be claimed before it expires. */
+export const CLAIM_DEADLINE_MS = 2 * 60 * 60 * 1000 // 2 hours
+
 // ─── Notification job payload ─────────────────────────────────────────────────
 
 export interface NotificationJobData {
@@ -223,7 +226,7 @@ async function handleExpireClaimDeadlines(): Promise<void> {
   })
 
   // Find the next WAITING entry for each expired slot in parallel
-  const claimDeadline = new Date(Date.now() + 2 * 60 * 60 * 1000) // +2h
+  const claimDeadline = new Date(Date.now() + CLAIM_DEADLINE_MS)
   const nextEntries = await Promise.all(
     expiredPromoted.map((entry) =>
       prisma.queueEntry.findFirst({

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -19,6 +19,21 @@ function defaultDateRange(): { startDate: Date; endDate: Date } {
   return { startDate, endDate }
 }
 
+function parseDateParam(value: string | undefined, suffix: 'T00:00:00.000Z' | 'T23:59:59.999Z', fallback: Date): Date {
+  return value ? new Date(value + suffix) : fallback
+}
+
+function countWorkingDays(start: Date, end: Date): number {
+  let days = 0
+  const cursor = new Date(start)
+  while (cursor <= end) {
+    const d = cursor.getDay()
+    if (d !== 0 && d !== 6) days++
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return days || 1
+}
+
 export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Analytics'], ...route.schema } })
 
@@ -35,18 +50,9 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       const defaults = defaultDateRange()
-      const startDate = result.data.startDate ? new Date(result.data.startDate + 'T00:00:00.000Z') : defaults.startDate
-      const endDate = result.data.endDate ? new Date(result.data.endDate + 'T23:59:59.999Z') : defaults.endDate
-
-      // Calculate working days in range (Mon–Fri)
-      let workingDays = 0
-      const cursor = new Date(startDate)
-      while (cursor <= endDate) {
-        const day = cursor.getDay()
-        if (day !== 0 && day !== 6) workingDays++
-        cursor.setDate(cursor.getDate() + 1)
-      }
-      if (workingDays === 0) workingDays = 1
+      const startDate = parseDateParam(result.data.startDate, 'T00:00:00.000Z', defaults.startDate)
+      const endDate = parseDateParam(result.data.endDate, 'T23:59:59.999Z', defaults.endDate)
+      const workingDays = countWorkingDays(startDate, endDate)
 
       // Build floor/building filters
       const floorWhere: Record<string, unknown> = {}
@@ -123,8 +129,8 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       const defaults = defaultDateRange()
-      const startDate = result.data.startDate ? new Date(result.data.startDate + 'T00:00:00.000Z') : defaults.startDate
-      const endDate = result.data.endDate ? new Date(result.data.endDate + 'T23:59:59.999Z') : defaults.endDate
+      const startDate = parseDateParam(result.data.startDate, 'T00:00:00.000Z', defaults.startDate)
+      const endDate = parseDateParam(result.data.endDate, 'T23:59:59.999Z', defaults.endDate)
 
       type BookingCountRow = { date: Date; count: bigint }
 
@@ -185,17 +191,9 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       if (!result.success) return reply.status(400).send({ error: { message: 'Invalid query', code: 'VALIDATION_ERROR' } })
 
       const defaults = defaultDateRange()
-      const startDate = result.data.startDate ? new Date(result.data.startDate + 'T00:00:00.000Z') : defaults.startDate
-      const endDate = result.data.endDate ? new Date(result.data.endDate + 'T23:59:59.999Z') : defaults.endDate
-
-      let workingDays = 0
-      const cursor = new Date(startDate)
-      while (cursor <= endDate) {
-        const day = cursor.getDay()
-        if (day !== 0 && day !== 6) workingDays++
-        cursor.setDate(cursor.getDate() + 1)
-      }
-      if (workingDays === 0) workingDays = 1
+      const startDate = parseDateParam(result.data.startDate, 'T00:00:00.000Z', defaults.startDate)
+      const endDate = parseDateParam(result.data.endDate, 'T23:59:59.999Z', defaults.endDate)
+      const workingDays = countWorkingDays(startDate, endDate)
 
       const bookingWhere: Record<string, unknown> = { startsAt: { gte: startDate, lte: endDate } }
 

--- a/apps/api/src/routes/bookings.ts
+++ b/apps/api/src/routes/bookings.ts
@@ -4,7 +4,7 @@ import { prisma } from '../lib/prisma'
 import { createBookingSchema, updateBookingSchema, GlobalRole, NotificationType } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
 import { requireGlobalRole } from '../middleware/requireRole'
-import { enqueueNotification, fanOutFloorAvailable } from '../lib/queue'
+import { enqueueNotification, fanOutFloorAvailable, CLAIM_DEADLINE_MS } from '../lib/queue'
 import { randomUUID } from 'crypto'
 import { checkGroupAccess } from './groups'
 import { z } from 'zod'
@@ -460,7 +460,7 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
     })
 
     if (nextQueued) {
-      const claimDeadline = new Date(Date.now() + 2 * 60 * 60 * 1000) // +2h
+      const claimDeadline = new Date(Date.now() + CLAIM_DEADLINE_MS)
       const claimToken = randomUUID()
       await prisma.queueEntry.update({
         where: { id: nextQueued.id },

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -117,6 +117,23 @@ function redactSecrets(provider: ProviderKey, config: Record<string, unknown>): 
   return redacted
 }
 
+async function serveUploadedFile(
+  reply: import('fastify').FastifyReply,
+  relativePath: string,
+  notFoundMessage: string,
+): Promise<void> {
+  const absPath = resolveStoragePath(relativePath)
+  try {
+    await fs.promises.access(absPath, fs.constants.R_OK)
+  } catch {
+    reply.status(404).send({ error: { message: notFoundMessage, code: 'FILE_NOT_FOUND' } })
+    return
+  }
+  reply.header('Content-Type', 'image/png')
+  reply.header('Cache-Control', 'public, max-age=300')
+  reply.send(fs.createReadStream(absPath))
+}
+
 export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Settings'], ...route.schema } })
 
@@ -286,15 +303,7 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
     if (!branding.logoPath) {
       return reply.status(404).send({ error: { message: 'Logo not set', code: 'NOT_FOUND' } })
     }
-    const absPath = resolveStoragePath(branding.logoPath as string)
-    try {
-      await fs.promises.access(absPath, fs.constants.R_OK)
-    } catch {
-      return reply.status(404).send({ error: { message: 'Logo file not found', code: 'FILE_NOT_FOUND' } })
-    }
-    reply.header('Content-Type', 'image/png')
-    reply.header('Cache-Control', 'public, max-age=300')
-    return reply.send(fs.createReadStream(absPath))
+    return serveUploadedFile(reply, branding.logoPath as string, 'Logo file not found')
   })
 
   // GET /settings/branding/favicon/image — serve favicon file (public)
@@ -304,15 +313,7 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
     if (!branding.faviconPath) {
       return reply.status(404).send({ error: { message: 'Favicon not set', code: 'NOT_FOUND' } })
     }
-    const absPath = resolveStoragePath(branding.faviconPath as string)
-    try {
-      await fs.promises.access(absPath, fs.constants.R_OK)
-    } catch {
-      return reply.status(404).send({ error: { message: 'Favicon file not found', code: 'FILE_NOT_FOUND' } })
-    }
-    reply.header('Content-Type', 'image/png')
-    reply.header('Cache-Control', 'public, max-age=300')
-    return reply.send(fs.createReadStream(absPath))
+    return serveUploadedFile(reply, branding.faviconPath as string, 'Favicon file not found')
   })
 
   // GET /settings/auth-config — list all provider configs (secrets redacted)


### PR DESCRIPTION
analytics.ts had the date-string-to-Date parse pattern and working-days
loop duplicated in three handlers. Both are now module-level helpers.

settings.ts had identical logo and favicon serve blocks (15 lines each).
Extracted to a serveUploadedFile helper and replaced both call sites.