### PR TITLE
fix(api): silence TS6.0 moduleResolution deprecation error

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary

- Adds `"ignoreDeprecations": "6.0"` to `apps/api/tsconfig.json`
- Fixes Docker build error `TS5107` introduced by TypeScript 6.0 promoting the `node`/`node10` moduleResolution deprecation from a warning to a hard error

## Why not migrate to `node16`?

`openid-client` and `pg-boss` are both pure-ESM packages currently imported via `require()` (allowed by `esModuleInterop`). `node16` resolution correctly rejects this pattern — fixing it requires converting those imports to async `import()` calls, which is a separate piece of work.

## Test plan

- [x] `pnpm --filter api build` completes with no errors
- [x] No source files changed — purely a compiler config fix

Closes #22