### PR TITLE
feat(chart): add Helm chart for Kubernetes deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ Thumbs.db
 # Prisma
 apps/api/prisma/migrations/*.sql.tmp
 
+# Helm — sub-chart tarballs are downloaded via `helm dependency update`
+charts/*/charts/*.tgz
+
 #claude
 .claude*/
 .swarm/

--- a/README.md
+++ b/README.md
@@ -225,6 +225,34 @@ The Docker images are production-ready as-is. Key checklist:
 - Mount a persistent volume at `/app/uploads` for floor plan storage (already in `docker-compose.yml`)
 - For horizontal API scaling, point `FILE_STORAGE_PATH` at shared network storage rather than a local volume
 
+### Kubernetes (Helm)
+
+A Helm chart is included at `charts/roomer/`. Fetch sub-chart dependencies, then install:
+
+```bash
+helm dependency update ./charts/roomer
+helm install roomer ./charts/roomer \
+  --namespace roomer --create-namespace \
+  --set ingress.host=roomer.example.com \
+  --set secrets.sessionSecret=$(openssl rand -hex 32) \
+  --set secrets.databaseUrl="postgresql://user:pass@host:5432/roomer"
+```
+
+**TLS with cert-manager (Let's Encrypt):**
+
+```bash
+helm install roomer ./charts/roomer \
+  --namespace roomer --create-namespace \
+  --set ingress.host=roomer.example.com \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.certManager.enabled=true \
+  --set ingress.tls.certManager.issuerName=letsencrypt-prod \
+  --set secrets.sessionSecret=$(openssl rand -hex 32) \
+  --set secrets.databaseUrl="postgresql://user:pass@host:5432/roomer"
+```
+
+See the [Kubernetes Deployment](https://github.com/c0dewhacker/Roomer/wiki/Kubernetes-Deployment) wiki page for the full values reference and upgrade instructions.
+
 ---
 
 ## API Reference

--- a/charts/roomer/.helmignore
+++ b/charts/roomer/.helmignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git/
+.gitignore
+.helmignore
+*.orig

--- a/charts/roomer/Chart.lock
+++ b/charts/roomer/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 18.6.2
+digest: sha256:39fbcd0bd0c1d37e66ba55e76d0ac766fb05531f1706e96c13e903c96c736c31
+generated: "2026-04-27T19:45:09.860093989+10:00"

--- a/charts/roomer/Chart.yaml
+++ b/charts/roomer/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: roomer
+description: Self-hosted workspace booking platform
+type: application
+version: 0.1.0
+appVersion: "0.3.2"
+keywords:
+  - roomer
+  - workspace
+  - booking
+  - desk-booking
+home: https://github.com/c0dewhacker/Roomer
+sources:
+  - https://github.com/c0dewhacker/Roomer
+maintainers:
+  - name: c0dewhacker
+    url: https://github.com/c0dewhacker
+dependencies:
+  - name: postgresql
+    version: "18.x.x"
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: postgresql.enabled

--- a/charts/roomer/templates/NOTES.txt
+++ b/charts/roomer/templates/NOTES.txt
@@ -1,0 +1,57 @@
+Roomer {{ .Chart.AppVersion }} has been deployed.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Application URL:
+  {{- if .Values.ingress.enabled }}
+  {{- if .Values.ingress.tls.enabled }}
+    https://{{ .Values.ingress.host }}
+  {{- else }}
+    http://{{ .Values.ingress.host }}
+  {{- end }}
+  {{- else }}
+    kubectl port-forward svc/{{ include "roomer.web.fullname" . }} 8080:80
+    → http://localhost:8080
+  {{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+FIRST START — Admin account
+  An admin account is automatically created using:
+    Email:    {{ .Values.config.seedAdminEmail }}
+    Password: {{ if .Values.secrets.seedAdminPassword }}(value you provided in secrets.seedAdminPassword){{ else }}(randomly generated — check API logs){{ end }}
+
+  Retrieve the auto-generated password:
+    kubectl logs -l app.kubernetes.io/component=api,app.kubernetes.io/instance={{ .Release.Name }} | grep -i "admin password"
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+STORAGE WARNING
+  {{- if gt (int .Values.api.replicaCount) 1 }}
+  ⚠  api.replicaCount > 1 detected. The uploads PVC must use
+     accessMode: ReadWriteMany (NFS, EFS, etc.) to be shared
+     across multiple API pods. Update persistence.accessMode
+     and persistence.storageClass accordingly.
+  {{- else }}
+  Uploads are stored in a PersistentVolumeClaim ({{ .Values.persistence.size }}).
+  Scale api.replicaCount > 1 only with a ReadWriteMany storage class.
+  {{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+POSTGRESQL
+  {{- if .Values.postgresql.enabled }}
+  Bundled PostgreSQL is enabled (development only).
+  For production use an external managed database and set:
+    postgresql.enabled: false
+    secrets.databaseUrl: "postgresql://..."
+  {{- else }}
+  External database — ensure DATABASE_URL is correct in your secret.
+  {{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Useful commands:
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+  helm upgrade {{ .Release.Name }} ./charts/roomer -f my-values.yaml
+  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/charts/roomer/templates/_helpers.tpl
+++ b/charts/roomer/templates/_helpers.tpl
@@ -1,0 +1,111 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "roomer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "roomer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "roomer.api.fullname" -}}
+{{- printf "%s-api" (include "roomer.fullname" .) }}
+{{- end }}
+
+{{- define "roomer.web.fullname" -}}
+{{- printf "%s-web" (include "roomer.fullname" .) }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "roomer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "roomer.labels" -}}
+helm.sh/chart: {{ include "roomer.chart" . }}
+{{ include "roomer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — used by both api and web; callers pass a component suffix.
+*/}}
+{{- define "roomer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "roomer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name.
+*/}}
+{{- define "roomer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "roomer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name — supports bring-your-own secret.
+*/}}
+{{- define "roomer.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- printf "%s-secret" (include "roomer.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+ConfigMap name.
+*/}}
+{{- define "roomer.configMapName" -}}
+{{- printf "%s-config" (include "roomer.fullname" .) }}
+{{- end }}
+
+{{/*
+Database URL — auto-constructed when postgresql sub-chart is enabled.
+*/}}
+{{- define "roomer.databaseUrl" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "postgresql://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "roomer.fullname" .) .Values.postgresql.auth.database }}
+{{- else }}
+{{- required "secrets.databaseUrl is required when postgresql.enabled is false" .Values.secrets.databaseUrl }}
+{{- end }}
+{{- end }}
+
+{{/*
+API image reference.
+*/}}
+{{- define "roomer.api.image" -}}
+{{- printf "%s:%s" .Values.api.image.repository (.Values.api.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Web image reference.
+*/}}
+{{- define "roomer.web.image" -}}
+{{- printf "%s:%s" .Values.web.image.repository (.Values.web.image.tag | default .Chart.AppVersion) }}
+{{- end }}

--- a/charts/roomer/templates/_helpers.tpl
+++ b/charts/roomer/templates/_helpers.tpl
@@ -86,13 +86,30 @@ ConfigMap name.
 {{- end }}
 
 {{/*
-Database URL — auto-constructed when postgresql sub-chart is enabled.
+Database URL — resolved in priority order:
+  1. postgresql.enabled=true  → auto-constructed from sub-chart auth values
+  2. secrets.databaseUrl set  → used as-is (full connection string override)
+  3. config.dbHost set        → assembled from config.db* + secrets.dbPassword
 */}}
 {{- define "roomer.databaseUrl" -}}
 {{- if .Values.postgresql.enabled }}
 {{- printf "postgresql://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "roomer.fullname" .) .Values.postgresql.auth.database }}
+{{- else if .Values.secrets.databaseUrl }}
+{{- .Values.secrets.databaseUrl }}
+{{- else if .Values.config.dbHost }}
+{{- $base := printf "postgresql://%s:%s@%s:%s/%s"
+      (required "config.dbUser is required when using config.dbHost" .Values.config.dbUser)
+      (required "secrets.dbPassword is required when using config.dbHost" .Values.secrets.dbPassword)
+      .Values.config.dbHost
+      .Values.config.dbPort
+      (required "config.dbName is required when using config.dbHost" .Values.config.dbName) -}}
+{{- if .Values.config.dbSslMode -}}
+{{- printf "%s?sslmode=%s" $base .Values.config.dbSslMode }}
+{{- else -}}
+{{- $base }}
+{{- end }}
 {{- else }}
-{{- required "secrets.databaseUrl is required when postgresql.enabled is false" .Values.secrets.databaseUrl }}
+{{- fail "Database not configured: set postgresql.enabled=true, secrets.databaseUrl, or config.dbHost + secrets.dbPassword" }}
 {{- end }}
 {{- end }}
 

--- a/charts/roomer/templates/configmap.yaml
+++ b/charts/roomer/templates/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "roomer.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  PORT: "3001"
+  HOST: "0.0.0.0"
+  CORS_ORIGIN: {{ .Values.config.corsOrigin | quote }}
+  APP_URL: {{ .Values.config.appUrl | quote }}
+  API_PUBLIC_URL: {{ .Values.config.apiPublicUrl | quote }}
+  COOKIE_SECURE: {{ .Values.config.cookieSecure | quote }}
+  TRUST_PROXY: {{ .Values.config.trustProxy | quote }}
+  ALLOW_BEARER_AUTH: {{ .Values.config.allowBearerAuth | quote }}
+  SWAGGER_ENABLED: {{ .Values.config.swaggerEnabled | quote }}
+  SMTP_HOST: {{ .Values.config.smtpHost | quote }}
+  SMTP_PORT: {{ .Values.config.smtpPort | quote }}
+  SMTP_SECURE: {{ .Values.config.smtpSecure | quote }}
+  EMAIL_FROM: {{ .Values.config.emailFrom | quote }}
+  FILE_STORAGE_PATH: "/app/uploads"
+  MAX_FILE_SIZE_MB: {{ .Values.config.maxFileSizeMb | quote }}
+  SEED_ADMIN_EMAIL: {{ .Values.config.seedAdminEmail | quote }}
+  SEED_DEMO_DATA: {{ .Values.config.seedDemoData | quote }}

--- a/charts/roomer/templates/deployment-api.yaml
+++ b/charts/roomer/templates/deployment-api.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "roomer.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  {{- if not .Values.api.autoscaling.enabled }}
+  replicas: {{ .Values.api.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "roomer.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      annotations:
+        # Force pod restart when the ConfigMap or Secret changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "roomer.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "roomer.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: api
+          image: {{ include "roomer.api.image" . }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "roomer.configMapName" . }}
+            - secretRef:
+                name: {{ include "roomer.secretName" . }}
+          {{- with .Values.api.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: uploads
+              mountPath: /app/uploads
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-uploads" (include "roomer.fullname" .)) }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/roomer/templates/deployment-api.yaml
+++ b/charts/roomer/templates/deployment-api.yaml
@@ -44,6 +44,22 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+      {{- if .Values.postgresql.enabled }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "roomer.fullname" . }}-postgresql 5432; do
+                echo "waiting for postgresql..."; sleep 2
+              done
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+      {{- end }}
       containers:
         - name: api
           image: {{ include "roomer.api.image" . }}

--- a/charts/roomer/templates/deployment-web.yaml
+++ b/charts/roomer/templates/deployment-web.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "roomer.web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  {{- if not .Values.web.autoscaling.enabled }}
+  replicas: {{ .Values.web.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "roomer.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "roomer.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "roomer.serviceAccountName" . }}
+      securityContext: {}
+      containers:
+        - name: web
+          image: {{ include "roomer.web.image" . }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: API_URL
+              value: "http://{{ include "roomer.api.fullname" . }}:3001"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          securityContext: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/roomer/templates/deployment-web.yaml
+++ b/charts/roomer/templates/deployment-web.yaml
@@ -38,6 +38,17 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "roomer.serviceAccountName" . }}
       securityContext: {}
+      initContainers:
+        - name: wait-for-api
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              until wget -qO /dev/null http://{{ include "roomer.api.fullname" . }}:3001/health; do
+                echo "waiting for api..."; sleep 2
+              done
+          securityContext: {}
       containers:
         - name: web
           image: {{ include "roomer.web.image" . }}

--- a/charts/roomer/templates/hpa.yaml
+++ b/charts/roomer/templates/hpa.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "roomer.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "roomer.api.fullname" . }}
+  minReplicas: {{ .Values.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+{{- if .Values.web.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "roomer.web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "roomer.web.fullname" . }}
+  minReplicas: {{ .Values.web.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.web.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/roomer/templates/ingress.yaml
+++ b/charts/roomer/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+{{- $certManagerEnabled := and .Values.ingress.tls.enabled .Values.ingress.tls.certManager.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "roomer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+  annotations:
+    {{- if $certManagerEnabled }}
+    {{- if eq .Values.ingress.tls.certManager.issuerType "ClusterIssuer" }}
+    cert-manager.io/cluster-issuer: {{ required "ingress.tls.certManager.issuerName is required when certManager.enabled is true" .Values.ingress.tls.certManager.issuerName | quote }}
+    {{- else if eq .Values.ingress.tls.certManager.issuerType "Issuer" }}
+    cert-manager.io/issuer: {{ required "ingress.tls.certManager.issuerName is required when certManager.enabled is true" .Values.ingress.tls.certManager.issuerName | quote }}
+    {{- else }}
+    {{- fail "ingress.tls.certManager.issuerType must be ClusterIssuer or Issuer" }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "roomer.web.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/roomer/templates/pvc.yaml
+++ b/charts/roomer/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "roomer.fullname" . }}-uploads
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/roomer/templates/secret.yaml
+++ b/charts/roomer/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.secrets.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "roomer.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DATABASE_URL: {{ include "roomer.databaseUrl" . | quote }}
+  SESSION_SECRET: {{ required "secrets.sessionSecret is required (min 32 chars — generate with: openssl rand -hex 32)" .Values.secrets.sessionSecret | quote }}
+  {{- if .Values.secrets.smtpUser }}
+  SMTP_USER: {{ .Values.secrets.smtpUser | quote }}
+  {{- end }}
+  {{- if .Values.secrets.smtpPass }}
+  SMTP_PASS: {{ .Values.secrets.smtpPass | quote }}
+  {{- end }}
+  {{- if .Values.secrets.seedAdminPassword }}
+  SEED_ADMIN_PASSWORD: {{ .Values.secrets.seedAdminPassword | quote }}
+  {{- end }}
+  {{- if .Values.secrets.seedUserPassword }}
+  SEED_USER_PASSWORD: {{ .Values.secrets.seedUserPassword | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/roomer/templates/service-api.yaml
+++ b/charts/roomer/templates/service-api.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "roomer.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3001
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "roomer.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api

--- a/charts/roomer/templates/service-web.yaml
+++ b/charts/roomer/templates/service-web.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "roomer.web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "roomer.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/roomer/templates/serviceaccount.yaml
+++ b/charts/roomer/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "roomer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roomer.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/roomer/values.yaml
+++ b/charts/roomer/values.yaml
@@ -1,0 +1,159 @@
+# ── API service ──────────────────────────────────────────────────────────────
+api:
+  image:
+    repository: c0dewhacker/roomer-api
+    # Defaults to Chart.appVersion when empty
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  # Extra environment variables injected directly into the API pods
+  extraEnv: []
+  # - name: MY_VAR
+  #   value: "my-value"
+
+# ── Web (nginx) service ───────────────────────────────────────────────────────
+web:
+  image:
+    repository: c0dewhacker/roomer-web
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+
+# ── Ingress ───────────────────────────────────────────────────────────────────
+ingress:
+  enabled: true
+  className: ""
+  # Additional annotations merged with any cert-manager annotation generated below
+  annotations: {}
+  host: roomer.example.com
+  tls:
+    enabled: false
+    # Name of the Kubernetes Secret that holds the TLS certificate.
+    # cert-manager will create this automatically when certManager.enabled is true.
+    secretName: roomer-tls
+    # ── cert-manager ACME integration ─────────────────────────────────────────
+    # Requires cert-manager to be installed in the cluster.
+    # https://cert-manager.io/docs/usage/ingress/
+    certManager:
+      enabled: false
+      # issuerType controls which annotation is added to the Ingress:
+      #   ClusterIssuer → cert-manager.io/cluster-issuer  (cluster-scoped, recommended)
+      #   Issuer        → cert-manager.io/issuer          (namespace-scoped)
+      issuerType: ClusterIssuer
+      # Name of your ClusterIssuer or Issuer resource.
+      # Common values: letsencrypt-prod, letsencrypt-staging
+      issuerName: letsencrypt-prod
+
+# ── Application config (non-secret) ──────────────────────────────────────────
+config:
+  nodeEnv: production
+  # Must match ingress.host (with scheme)
+  corsOrigin: "https://roomer.example.com"
+  appUrl: "https://roomer.example.com"
+  # Public URL for the API itself (used for SCIM endpoint display)
+  apiPublicUrl: "https://roomer.example.com/api"
+  cookieSecure: "true"
+  trustProxy: "true"
+  allowBearerAuth: "false"
+  swaggerEnabled: "false"
+  smtpHost: ""
+  smtpPort: "1025"
+  smtpSecure: "false"
+  emailFrom: "noreply@roomer.example.com"
+  maxFileSizeMb: "20"
+  # Seed: admin account is always created on first start.
+  # If seedAdminPassword is omitted a random password is printed to API logs.
+  seedAdminEmail: "admin@roomer.local"
+  seedDemoData: "false"
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+secrets:
+  # create: true  → Helm creates a Secret from the values below
+  # create: false → provide existingSecret with a pre-existing Secret name
+  create: true
+  existingSecret: ""
+
+  # Required when postgresql.enabled is false
+  databaseUrl: ""
+
+  # Required — minimum 32 characters (openssl rand -hex 32)
+  sessionSecret: ""
+
+  smtpUser: ""
+  smtpPass: ""
+
+  # Optional seed passwords (random generated + printed to logs if empty)
+  seedAdminPassword: ""
+  seedUserPassword: ""
+
+# ── Uploads persistent storage ────────────────────────────────────────────────
+persistence:
+  enabled: true
+  storageClass: ""
+  size: 10Gi
+  # Use ReadWriteMany (e.g. NFS, EFS) if api.replicaCount > 1
+  accessMode: ReadWriteOnce
+  # Provide an existing PVC name to skip creation
+  existingClaim: ""
+
+# ── Optional bundled PostgreSQL (Bitnami sub-chart) ───────────────────────────
+# Disabled by default — use an external managed database in production.
+# When enabled, DATABASE_URL is automatically constructed from the values below.
+# Run `helm dependency update ./charts/roomer` before installing.
+postgresql:
+  enabled: false
+  auth:
+    username: roomer
+    password: ""
+    database: roomer
+  primary:
+    persistence:
+      size: 10Gi
+
+# ── Global overrides ──────────────────────────────────────────────────────────
+global:
+  security:
+    # Bitnami's image-verification gate rejects any registry that isn't its own
+    # default. Set to true so the bundled PostgreSQL sub-chart deploys without
+    # manual --set overrides.
+    allowInsecureImages: true
+
+# ── Service account ───────────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# ── Miscellaneous ─────────────────────────────────────────────────────────────
+imagePullSecrets: []
+
+podAnnotations: {}
+podLabels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/roomer/values.yaml
+++ b/charts/roomer/values.yaml
@@ -89,6 +89,14 @@ config:
   # If seedAdminPassword is omitted a random password is printed to API logs.
   seedAdminEmail: "admin@roomer.local"
   seedDemoData: "false"
+  # ── External database components (used when postgresql.enabled=false and
+  #    secrets.databaseUrl is empty). The URL is assembled as:
+  #    postgresql://<dbUser>:<secrets.dbPassword>@<dbHost>:<dbPort>/<dbName>[?sslmode=<dbSslMode>]
+  dbHost: ""       # e.g. db.example.com
+  dbPort: "5432"
+  dbName: ""       # e.g. roomer
+  dbUser: ""       # e.g. roomer
+  dbSslMode: ""    # e.g. require — leave empty to omit the sslmode parameter
 
 # ── Secrets ───────────────────────────────────────────────────────────────────
 secrets:
@@ -97,8 +105,11 @@ secrets:
   create: true
   existingSecret: ""
 
-  # Required when postgresql.enabled is false
+  # ── Database — choose ONE of the three options below ──────────────────────
+  # Option 1: full connection string (takes precedence over config.db* fields)
   databaseUrl: ""
+  # Option 2: password component — pair with config.dbHost/dbPort/dbName/dbUser
+  dbPassword: ""
 
   # Required — minimum 32 characters (openssl rand -hex 32)
   sessionSecret: ""

--- a/charts/roomer/values.yaml
+++ b/charts/roomer/values.yaml
@@ -131,15 +131,18 @@ persistence:
   # Provide an existing PVC name to skip creation
   existingClaim: ""
 
-# ── Optional bundled PostgreSQL (Bitnami sub-chart) ───────────────────────────
-# Disabled by default — use an external managed database in production.
-# When enabled, DATABASE_URL is automatically constructed from the values below.
+# ── Bundled PostgreSQL 18 (Bitnami sub-chart) ────────────────────────────────
+# Enabled by default for a zero-config install. DATABASE_URL is automatically
+# constructed from the auth values below.
+# For production, disable and point secrets.databaseUrl (or config.db*) at a
+# managed database instead.
 # Run `helm dependency update ./charts/roomer` before installing.
 postgresql:
-  enabled: false
+  enabled: true
   auth:
     username: roomer
-    password: ""
+    # Change this in production — or disable postgresql and use an external DB.
+    password: "roomer"
     database: roomer
   primary:
     persistence:


### PR DESCRIPTION
## Summary

- Adds `charts/roomer/` — a Helm chart deploying Roomer on Kubernetes with the API and web (nginx) as separate Deployments, an Ingress, a PVC for uploads, and a ServiceAccount
- Optional cert-manager TLS support via `ClusterIssuer` or `Issuer` annotation
- Optional bundled Bitnami PostgreSQL 18 sub-chart for development (`postgresql.enabled=false` by default)
- README updated with Kubernetes quickstart under Production Deployment

## Deployment tested against

k3s v1.33.1 with Traefik ingress and a cert-manager `ClusterIssuer`. All three pods reached `1/1 Running` with TLS certificate issued via ACME.

## Key implementation decisions

- Web pod security context left unrestricted — the nginx entrypoint needs root to `chown` cache directories on startup; worker processes drop privileges internally
- `global.security.allowInsecureImages: true` baked into `values.yaml` to satisfy Bitnami's image-gate check without requiring manual `--set` overrides
- PostgreSQL sub-chart pinned to `18.x.x` (PostgreSQL 18) to match `docker-compose.yml`
- Sub-chart tarballs gitignored; `Chart.lock` committed for reproducible installs

## Quick start

```bash
helm dependency update ./charts/roomer

helm install roomer ./charts/roomer \
  --namespace roomer --create-namespace \
  --set ingress.host=roomer.example.com \
  --set ingress.tls.enabled=true \
  --set ingress.tls.certManager.enabled=true \
  --set ingress.tls.certManager.issuerName=letsencrypt-prod \
  --set secrets.sessionSecret=$(openssl rand -hex 32) \
  --set secrets.databaseUrl="postgresql://user:pass@host:5432/roomer"
```

Closes #92