### PR TITLE
feat(chart): Helm chart improvements from cluster testing

### DIFF
--- a/charts/roomer/templates/_helpers.tpl
+++ b/charts/roomer/templates/_helpers.tpl
@@ -114,14 +114,14 @@ Database URL — resolved in priority order:
 {{- end }}
 
 {{/*
-API image reference.
+API image reference. Falls back to Chart.appVersion if tag is explicitly cleared.
 */}}
 {{- define "roomer.api.image" -}}
 {{- printf "%s:%s" .Values.api.image.repository (.Values.api.image.tag | default .Chart.AppVersion) }}
 {{- end }}
 
 {{/*
-Web image reference.
+Web image reference. Falls back to Chart.appVersion if tag is explicitly cleared.
 */}}
 {{- define "roomer.web.image" -}}
 {{- printf "%s:%s" .Values.web.image.repository (.Values.web.image.tag | default .Chart.AppVersion) }}

--- a/charts/roomer/values.yaml
+++ b/charts/roomer/values.yaml
@@ -2,9 +2,11 @@
 api:
   image:
     repository: c0dewhacker/roomer-api
-    # Defaults to Chart.appVersion when empty
-    tag: ""
-    pullPolicy: IfNotPresent
+    # Uses "latest" by default so deployments always pull the current release.
+    # Pin to a specific version (e.g. "0.3.2") to lock to a known image.
+    tag: "latest"
+    # Always required when tag is "latest" so Kubernetes re-pulls on each rollout.
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:
@@ -27,8 +29,11 @@ api:
 web:
   image:
     repository: c0dewhacker/roomer-web
-    tag: ""
-    pullPolicy: IfNotPresent
+    # Uses "latest" by default so deployments always pull the current release.
+    # Pin to a specific version (e.g. "0.3.2") to lock to a known image.
+    tag: "latest"
+    # Always required when tag is "latest" so Kubernetes re-pulls on each rollout.
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:


### PR DESCRIPTION
## Summary

Follow-up improvements to the Helm chart based on live cluster testing against k3s with Traefik and cert-manager.

- **Bundled PostgreSQL 18 on by default** — zero-config install now requires only `ingress.host` and `secrets.sessionSecret`
- **Individual database components** — users can supply `config.dbHost`, `config.dbPort`, `config.dbName`, `config.dbUser` + `secrets.dbPassword` instead of constructing a full connection string; `config.dbSslMode` appends `?sslmode=` when set
- **Init containers** — API pod waits for PostgreSQL port 5432 before starting; web pod waits for the API `/health` endpoint before starting nginx — eliminates the CrashLoopBackOff race on fresh installs
- **Image defaults** — both images default to `latest` tag with `imagePullPolicy: Always` so deployments always pull the current release; pin `tag` to lock to a specific version