### PR TITLE
feat: ROOMER_ env namespace + AES-256-GCM encryption at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,26 +1,45 @@
-# ─── Required ─────────────────────────────────────────────────────────────────
+# ─── Database ─────────────────────────────────────────────────────────────────
+ROOMER_DATABASE_URL=postgresql://roomer:roomer@localhost:5435/roomer
 
-# Cookie signing secret. Must be at least 32 characters.
+# ─── Session ──────────────────────────────────────────────────────────────────
+# Must be at least 32 characters — generate with: openssl rand -hex 32
+ROOMER_SESSION_SECRET=replace-me-with-a-random-32-char-string-or-longer
+
+# ─── Server ───────────────────────────────────────────────────────────────────
+ROOMER_WEB_PORT=3001
+# ROOMER_APP_URL=http://localhost:5173
+# ROOMER_API_PUBLIC_URL=http://localhost:3001
+# ─── CORS ─────────────────────────────────────────────────────────────────────
+ROOMER_CORS_ORIGIN=http://localhost:5173
+
+# ROOMER_COOKIE_SECURE=false
+# ROOMER_TRUST_PROXY=false
+# ROOMER_ALLOW_BEARER_AUTH=true
+# ROOMER_SWAGGER_ENABLED=true
+
+# ─── File storage ─────────────────────────────────────────────────────────────
+ROOMER_FILE_STORAGE_PATH=./uploads
+ROOMER_MAX_FILE_SIZE_MB=20
+
+# AES-256-GCM encryption key ──────────────────────────────────
 # Generate with: openssl rand -hex 32
-SESSION_SECRET=
+ROOMER_ENCRYPTION_KEY=replace-me-with-a-random-32-char-string-or-longer
 
-# ─── Application URLs ─────────────────────────────────────────────────────────
+# ─── Email (SMTP) ─────────────────────────────────────────────────────────────
+# For local dev with Mailhog/Mailcatcher (no auth required):
+# ROOMER_SMTP_HOST=localhost
+# ROOMER_SMTP_PORT=1025
+# ROOMER_SMTP_SECURE=false
+# ROOMER_SMTP_USER=
+# ROOMER_SMTP_PASS=
+# ROOMER_EMAIL_FROM=noreply@roomer.local
+# ROOMER_SEED_ADMIN_EMAIL=admin@roomer.local
 
-# Public origin of the web app. Used for CORS and links in system emails.
-# Include the scheme and port if non-standard (e.g. https://roomer.example.com).
-APP_ORIGIN=http://localhost
+ROOMER_EMAIL_FROM=Roomer <noreply@example.com>
+ROOMER_APP_URL=http://localhost:5173
 
-# ─── Web server ───────────────────────────────────────────────────────────────
+# ─── SEED data vars ─────────────────────────────────────────────────────────────
+# ROOMER_SEED_ADMIN_PASSWORD=
+# ROOMER_SEED_USER_PASSWORD=
+# ROOMER_SEED_DEMO_DATA=false
 
-# Host port to expose the web container on.
-WEB_PORT=80
-
-# ─── Security ─────────────────────────────────────────────────────────────────
-
-# Set to true when serving over HTTPS to apply the Secure flag to session cookies.
-COOKIE_SECURE=false
-
-# ─── Email ────────────────────────────────────────────────────────────────────
-
-# Sender address used for booking confirmations and queue notifications.
-EMAIL_FROM=noreply@roomer.local

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,43 +1,48 @@
 # ─── Database ─────────────────────────────────────────────────────────────────
-DATABASE_URL=postgresql://roomer:roomer@localhost:5435/roomer
+ROOMER_DATABASE_URL=postgresql://roomer:roomer@localhost:5435/roomer
 
 # ─── Session ──────────────────────────────────────────────────────────────────
 # Must be at least 32 characters — generate with: openssl rand -hex 32
-SESSION_SECRET=replace-me-with-a-random-32-char-string-or-longer
+ROOMER_SESSION_SECRET=replace-me-with-a-random-32-char-string-or-longer
 
 # ─── Server ───────────────────────────────────────────────────────────────────
 NODE_ENV=development
-PORT=3001
-HOST=0.0.0.0
-
+ROOMER_PORT=3001
+ROOMER_HOST=0.0.0.0
+# ROOMER_APP_URL=http://localhost:5173
+# ROOMER_API_PUBLIC_URL=http://localhost:3001
 # ─── CORS ─────────────────────────────────────────────────────────────────────
-CORS_ORIGIN=http://localhost:5173
+ROOMER_CORS_ORIGIN=http://localhost:5173
+
+# ROOMER_COOKIE_SECURE=false
+# ROOMER_TRUST_PROXY=false
+# ROOMER_ALLOW_BEARER_AUTH=true
+# ROOMER_SWAGGER_ENABLED=true
 
 # ─── File storage ─────────────────────────────────────────────────────────────
-FILE_STORAGE_PATH=./uploads
-MAX_FILE_SIZE_MB=20
+ROOMER_FILE_STORAGE_PATH=./uploads
+ROOMER_MAX_FILE_SIZE_MB=20
+
+# AES-256-GCM encryption key ──────────────────────────────────
+# Generate with: openssl rand -hex 32
+ROOMER_ENCRYPTION_KEY=replace-me-with-a-random-32-char-string-or-longer
+
 
 # ─── Email (SMTP) ─────────────────────────────────────────────────────────────
 # For local dev with Mailhog/Mailcatcher (no auth required):
-SMTP_HOST=localhost
-SMTP_PORT=1025
-SMTP_SECURE=false
-#SMTP_USER=
-#SMTP_PASS=
+# ROOMER_SMTP_HOST=localhost
+# ROOMER_SMTP_PORT=1025
+# ROOMER_SMTP_SECURE=false
+# ROOMER_SMTP_USER=
+# ROOMER_SMTP_PASS=
+# ROOMER_EMAIL_FROM=noreply@roomer.local
+# ROOMER_SEED_ADMIN_EMAIL=admin@roomer.local
 
-# For Gmail:
-#SMTP_HOST=smtp.gmail.com
-#SMTP_PORT=587
-#SMTP_SECURE=false
-#SMTP_USER=you@gmail.com
-#SMTP_PASS=your-app-password
+ROOMER_EMAIL_FROM=Roomer <noreply@example.com>
+ROOMER_APP_URL=http://localhost:5173
 
-# For SendGrid:
-#SMTP_HOST=smtp.sendgrid.net
-#SMTP_PORT=587
-#SMTP_SECURE=false
-#SMTP_USER=apikey
-#SMTP_PASS=SG.your-api-key
+# ─── SEED data vars ─────────────────────────────────────────────────────────────
+# ROOMER_SEED_ADMIN_PASSWORD=
+# ROOMER_SEED_USER_PASSWORD=
+# ROOMER_SEED_DEMO_DATA=false
 
-EMAIL_FROM=Roomer <noreply@example.com>
-APP_URL=http://localhost:5173

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -3,7 +3,9 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { Pool } from 'pg'
 import bcryptjs from 'bcryptjs'
 
-const pool = new Pool({ connectionString: process.env['DATABASE_URL'] })
+const r = (name: string): string | undefined => process.env[`ROOMER_${name}`] ?? process.env[name]
+
+const pool = new Pool({ connectionString: r('DATABASE_URL') })
 const adapter = new PrismaPg(pool)
 const prisma = new PrismaClient({ adapter })
 
@@ -27,8 +29,8 @@ async function seedCore() {
   // Super-admin — use SEED_ADMIN_EMAIL / SEED_ADMIN_PASSWORD env vars.
   // If SEED_ADMIN_PASSWORD is unset a secure random password is generated and
   // printed once to stdout — there is no hardcoded default credential.
-  const adminEmail = process.env['SEED_ADMIN_EMAIL'] ?? 'admin@roomer.local'
-  const rawAdminPassword = process.env['SEED_ADMIN_PASSWORD'] ?? (() => {
+  const adminEmail = r('SEED_ADMIN_EMAIL') ?? 'admin@roomer.local'
+  const rawAdminPassword = r('SEED_ADMIN_PASSWORD') ?? (() => {
     const generated = require('crypto').randomBytes(16).toString('hex')
     console.log(`[seed] SEED_ADMIN_PASSWORD not set — generated password: ${generated}`)
     return generated
@@ -56,7 +58,7 @@ async function seedCore() {
 
 async function seedDemoData(orgId: string) {
   // Regular test user
-  const rawUserPassword = process.env['SEED_USER_PASSWORD'] ?? (() => {
+  const rawUserPassword = r('SEED_USER_PASSWORD') ?? (() => {
     const generated = require('crypto').randomBytes(16).toString('hex')
     console.log(`[seed] SEED_USER_PASSWORD not set — generated password: ${generated}`)
     return generated
@@ -172,7 +174,7 @@ async function seedDemoData(orgId: string) {
 // ─── Entry point ──────────────────────────────────────────────────────────────
 
 async function main() {
-  const seedDemo = process.env['SEED_DEMO_DATA'] === 'true'
+  const seedDemo = r('SEED_DEMO_DATA') === 'true'
   console.log(`[seed] Starting (demo data: ${seedDemo})`)
 
   const { org } = await seedCore()

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,10 +1,22 @@
 import { z } from 'zod'
 
+// Resolve a variable by checking ROOMER_<NAME> first, then <NAME>.
+// This lets Docker/Kubernetes deployments use a consistent ROOMER_ namespace
+// while preserving backward compatibility with unprefixed names.
+function r(name: string): string | undefined {
+  return process.env[`ROOMER_${name}`] ?? process.env[name]
+}
+
+const isProd = r('NODE_ENV') === 'production'
+
 const envSchema = z.object({
-  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
-  // Minimum 32 characters. For maximum security use 64 hex characters (32 random bytes).
-  // Generate with: openssl rand -hex 32
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL (or ROOMER_DATABASE_URL) is required'),
+  // Minimum 32 characters. Generate with: openssl rand -hex 32
   SESSION_SECRET: z.string().min(32, 'SESSION_SECRET must be at least 32 characters. Generate with: openssl rand -hex 32'),
+  // 32-byte hex key for AES-256-GCM encryption of sensitive DB fields (AuthConfig secrets).
+  // Generate with: openssl rand -hex 32
+  ROOMER_ENCRYPTION_KEY: z.string()
+    .regex(/^[0-9a-f]{64}$/, 'ROOMER_ENCRYPTION_KEY must be exactly 64 lowercase hex characters (32 bytes). Generate with: openssl rand -hex 32'),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   PORT: z.coerce.number().default(3001),
   HOST: z.string().default('0.0.0.0'),
@@ -17,24 +29,23 @@ const envSchema = z.object({
   // Set to "true" to require the Secure flag on cookies. Should be "true" in any
   // environment served over HTTPS — including staging. Defaults to true in production.
   COOKIE_SECURE: z.string()
-    .default(process.env.NODE_ENV === 'production' ? 'true' : 'false')
+    .default(isProd ? 'true' : 'false')
     .transform((v) => v === 'true'),
   // Set to "true" only in production/staging behind a trusted reverse proxy.
   // When false, X-Forwarded-For headers are ignored (prevents rate-limit bypass).
   TRUST_PROXY: z.string()
-    .default(process.env.NODE_ENV === 'production' ? 'true' : 'false')
+    .default(isProd ? 'true' : 'false')
     .transform((v) => v === 'true'),
   // Set to "true" to allow Authorization: Bearer <token> in addition to cookies.
   // Disabled by default in production — opt-in only for programmatic API clients
   // that cannot use cookies (e.g. server-to-server, CI, mobile native apps).
   ALLOW_BEARER_AUTH: z.string()
-    .default(process.env.NODE_ENV === 'production' ? 'false' : 'true')
+    .default(isProd ? 'false' : 'true')
     .transform((v) => v === 'true'),
   // Set to "true" to expose the Swagger UI and OpenAPI schema endpoint.
   // Defaults to enabled in development/test and disabled in production.
-  // Override with SWAGGER_ENABLED=true to enable in production (e.g. for internal tooling).
   SWAGGER_ENABLED: z.string()
-    .default(process.env.NODE_ENV === 'production' ? 'false' : 'true')
+    .default(isProd ? 'false' : 'true')
     .transform((v) => v === 'true'),
   FILE_STORAGE_PATH: z.string().default('./uploads'),
   MAX_FILE_SIZE_MB: z.coerce.number().default(20),
@@ -51,9 +62,40 @@ const envSchema = z.object({
   // Public-facing base URL for the API itself (used for SCIM endpoint URLs shown in the admin UI).
   // Defaults to localhost in development; set to e.g. https://api.example.com in production.
   API_PUBLIC_URL: z.string().url().default('http://localhost:3001'),
+  // ── Seed variables (used only at first-run / prisma db seed) ─────────────
+  SEED_ADMIN_EMAIL: z.string().email().optional(),
+  SEED_ADMIN_PASSWORD: z.string().optional(),
+  SEED_USER_PASSWORD: z.string().optional(),
+  SEED_DEMO_DATA: z.string().default('false').transform((v) => v === 'true'),
 })
 
-const parsed = envSchema.safeParse(process.env)
+const parsed = envSchema.safeParse({
+  DATABASE_URL:           r('DATABASE_URL'),
+  SESSION_SECRET:         r('SESSION_SECRET'),
+  ROOMER_ENCRYPTION_KEY:  process.env['ROOMER_ENCRYPTION_KEY'],
+  NODE_ENV:               r('NODE_ENV'),
+  PORT:                   r('PORT'),
+  HOST:                   r('HOST'),
+  CORS_ORIGIN:            r('CORS_ORIGIN'),
+  COOKIE_SECURE:          r('COOKIE_SECURE'),
+  TRUST_PROXY:            r('TRUST_PROXY'),
+  ALLOW_BEARER_AUTH:      r('ALLOW_BEARER_AUTH'),
+  SWAGGER_ENABLED:        r('SWAGGER_ENABLED'),
+  FILE_STORAGE_PATH:      r('FILE_STORAGE_PATH'),
+  MAX_FILE_SIZE_MB:       r('MAX_FILE_SIZE_MB'),
+  SMTP_HOST:              r('SMTP_HOST'),
+  SMTP_PORT:              r('SMTP_PORT'),
+  SMTP_SECURE:            r('SMTP_SECURE'),
+  SMTP_USER:              r('SMTP_USER'),
+  SMTP_PASS:              r('SMTP_PASS'),
+  EMAIL_FROM:             r('EMAIL_FROM'),
+  APP_URL:                r('APP_URL'),
+  API_PUBLIC_URL:         r('API_PUBLIC_URL'),
+  SEED_ADMIN_EMAIL:       r('SEED_ADMIN_EMAIL'),
+  SEED_ADMIN_PASSWORD:    r('SEED_ADMIN_PASSWORD'),
+  SEED_USER_PASSWORD:     r('SEED_USER_PASSWORD'),
+  SEED_DEMO_DATA:         r('SEED_DEMO_DATA'),
+})
 
 if (!parsed.success) {
   console.error('Invalid environment variables:')

--- a/apps/api/src/lib/encryption.ts
+++ b/apps/api/src/lib/encryption.ts
@@ -1,0 +1,44 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+import { env } from '../env'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_BYTES = 12   // 96-bit IV — recommended for GCM
+const TAG_BYTES = 16  // 128-bit auth tag
+
+const KEY = Buffer.from(env.ROOMER_ENCRYPTION_KEY, 'hex')
+
+export function encrypt(plaintext: string): string {
+  const iv = randomBytes(IV_BYTES)
+  const cipher = createCipheriv(ALGORITHM, KEY, iv)
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return `enc:v1:${Buffer.concat([iv, ciphertext, tag]).toString('base64')}`
+}
+
+export function decrypt(envelope: string): string {
+  if (!envelope.startsWith('enc:v1:')) throw new Error('Not an encrypted envelope')
+  const payload = Buffer.from(envelope.slice(7), 'base64')
+  if (payload.length < IV_BYTES + TAG_BYTES) throw new Error('Malformed encrypted envelope')
+  const iv = payload.subarray(0, IV_BYTES)
+  const tag = payload.subarray(payload.length - TAG_BYTES)
+  const ciphertext = payload.subarray(IV_BYTES, payload.length - TAG_BYTES)
+  const decipher = createDecipheriv(ALGORITHM, KEY, iv)
+  decipher.setAuthTag(tag)
+  return decipher.update(ciphertext) + decipher.final('utf8')
+}
+
+// Serialize an object to JSON, encrypt, and return the enc:v1: envelope string.
+// Store the result directly in a Prisma Json field — Postgres stores it as a JSON string.
+export function encryptJson(value: unknown): string {
+  return encrypt(JSON.stringify(value))
+}
+
+// Decrypt a value from a Prisma Json field.
+// - If it's a string starting with enc:v1: → decrypt and JSON.parse.
+// - Otherwise pass through as-is (legacy plaintext rows before backfill).
+export function decryptJson<T = unknown>(value: unknown): T {
+  if (typeof value === 'string' && value.startsWith('enc:v1:')) {
+    return JSON.parse(decrypt(value)) as T
+  }
+  return value as T
+}

--- a/apps/api/src/lib/ldap.ts
+++ b/apps/api/src/lib/ldap.ts
@@ -1,5 +1,5 @@
 import ldap from 'ldapjs'
-import { prisma } from './prisma'
+import { prisma, findAuthConfig } from './prisma'
 import type { GroupMapping } from './group-mapping'
 
 export interface LdapConfig {
@@ -34,7 +34,7 @@ export interface LdapSyncResult {
 }
 
 export async function getLdapConfig(): Promise<LdapConfig | null> {
-  const row = await prisma.authConfig.findUnique({ where: { provider: 'LDAP' } })
+  const row = await findAuthConfig('LDAP')
   if (!row || !row.enabled) return null
   const cfg = row.config as unknown as LdapConfig
   if (!cfg.url || !cfg.searchBase) return null

--- a/apps/api/src/lib/oidc.ts
+++ b/apps/api/src/lib/oidc.ts
@@ -1,5 +1,5 @@
 import { discovery, randomState, randomNonce, type Configuration, ClientSecretPost } from 'openid-client'
-import { prisma } from './prisma'
+import { findAuthConfig } from './prisma'
 import type { GroupMapping } from './group-mapping'
 
 export interface OidcConfig {
@@ -21,7 +21,7 @@ let cachedIssuerUrl: string | null = null
 let cachedAt: number = 0
 
 export async function getOidcClientConfig(): Promise<Configuration | null> {
-  const row = await prisma.authConfig.findUnique({ where: { provider: 'OIDC' } })
+  const row = await findAuthConfig('OIDC')
   if (!row || !row.enabled) return null
 
   const cfg = row.config as unknown as OidcConfig
@@ -58,7 +58,7 @@ export function generateNonce(): string {
 }
 
 export async function getOidcConfig(): Promise<OidcConfig | null> {
-  const row = await prisma.authConfig.findUnique({ where: { provider: 'OIDC' } })
+  const row = await findAuthConfig('OIDC')
   if (!row || !row.enabled) return null
   return row.config as unknown as OidcConfig
 }

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -1,6 +1,10 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { Pool } from 'pg'
+import { encryptJson, decryptJson } from './encryption'
+
+const dbUrl = process.env['ROOMER_DATABASE_URL'] ?? process.env['DATABASE_URL']
+const nodeEnv = process.env['ROOMER_NODE_ENV'] ?? process.env['NODE_ENV']
 
 declare global {
   // Allow global prisma in development to survive hot reloads
@@ -9,18 +13,56 @@ declare global {
 }
 
 function createPrismaClient(): PrismaClient {
-  const pool = new Pool({ connectionString: process.env['DATABASE_URL'] })
+  const pool = new Pool({ connectionString: dbUrl })
   const adapter = new PrismaPg(pool)
   return new PrismaClient({
     adapter,
-    log:
-      process.env['NODE_ENV'] === 'development'
-        ? ['query', 'info', 'warn', 'error']
-        : ['warn', 'error'],
+    log: nodeEnv === 'development' ? ['query', 'info', 'warn', 'error'] : ['warn', 'error'],
   })
 }
 
 export const prisma: PrismaClient =
-  process.env['NODE_ENV'] === 'production'
+  nodeEnv === 'production'
     ? createPrismaClient()
     : (global.__prisma ?? (global.__prisma = createPrismaClient()))
+
+// ── AuthConfig encrypted accessors ───────────────────────────────────────────
+// AuthConfig.config stores sensitive credentials (OIDC clientSecret, LDAP
+// bindCredentials). These functions transparently encrypt on write and decrypt
+// on read so all callsites get plain objects without handling encryption directly.
+
+type AuthConfigProvider = 'OIDC' | 'SAML' | 'LDAP'
+
+function decryptConfig<T extends { config: Prisma.JsonValue }>(row: T): T {
+  return { ...row, config: decryptJson(row.config) }
+}
+
+export async function findAuthConfig(provider: AuthConfigProvider) {
+  const row = await prisma.authConfig.findUnique({ where: { provider } })
+  return row ? decryptConfig(row) : null
+}
+
+export async function listAuthConfigs() {
+  const rows = await prisma.authConfig.findMany()
+  return rows.map(decryptConfig)
+}
+
+export async function upsertAuthConfig(
+  provider: AuthConfigProvider,
+  data: { enabled?: boolean; config?: Record<string, unknown> },
+) {
+  const encryptedConfig = data.config !== undefined ? encryptJson(data.config) : undefined
+  const row = await prisma.authConfig.upsert({
+    where: { provider },
+    update: {
+      ...(typeof data.enabled === 'boolean' ? { enabled: data.enabled } : {}),
+      ...(encryptedConfig !== undefined ? { config: encryptedConfig } : {}),
+    },
+    create: {
+      provider,
+      enabled: data.enabled ?? false,
+      config: encryptedConfig ?? '{}',
+    },
+  })
+  return decryptConfig(row)
+}

--- a/apps/api/src/lib/saml.ts
+++ b/apps/api/src/lib/saml.ts
@@ -1,5 +1,5 @@
 import { SAML } from '@node-saml/node-saml'
-import { prisma } from './prisma'
+import { findAuthConfig } from './prisma'
 import type { GroupMapping } from './group-mapping'
 
 export interface SamlConfig {
@@ -21,7 +21,7 @@ export interface SamlConfig {
 }
 
 export async function getSamlConfig(): Promise<SamlConfig | null> {
-  const row = await prisma.authConfig.findUnique({ where: { provider: 'SAML' } })
+  const row = await findAuthConfig('SAML')
   if (!row || !row.enabled) return null
   const cfg = row.config as unknown as SamlConfig
   if (!cfg.entryPoint || !cfg.cert || !cfg.callbackUrl) return null

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -9,6 +9,7 @@ import { Prisma } from '@prisma/client'
 import { invalidateOidcCache } from '../lib/oidc'
 import { syncLdapUsers, getLdapConfig } from '../lib/ldap'
 import { hashScimToken, generateScimToken } from '../lib/scim-helpers'
+import { findAuthConfig, listAuthConfigs, upsertAuthConfig } from '../lib/prisma'
 import { saveBrandingImage, resolveStoragePath } from '../lib/storage'
 import { DEFAULT_TEMPLATE_STRINGS, interpolateTemplate, stripHtmlToText, formatDate, sendEmail } from '../lib/mailer'
 import { z } from 'zod'
@@ -332,7 +333,7 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
     '/auth-config',
     { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
     async (_request, reply) => {
-      const rows = await prisma.authConfig.findMany()
+      const rows = await listAuthConfigs()
       const result: Record<string, unknown> = {}
       for (const row of rows) {
         result[row.provider] = {
@@ -365,7 +366,7 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
 
       if (body.config) {
         // Merge with existing config to support partial updates (keep secrets if not provided)
-        const existing = await prisma.authConfig.findUnique({ where: { provider: upperProvider } })
+        const existing = await findAuthConfig(upperProvider)
         const existingConfig = (existing?.config ?? {}) as Record<string, unknown>
         mergedConfig = { ...existingConfig }
 
@@ -393,17 +394,9 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
         }
       }
 
-      const row = await prisma.authConfig.upsert({
-        where: { provider: upperProvider },
-        update: {
-          ...(typeof body.enabled === 'boolean' ? { enabled: body.enabled } : {}),
-          ...(body.config ? { config: mergedConfig as Record<string, string> } : {}),
-        },
-        create: {
-          provider: upperProvider,
-          enabled: body.enabled ?? false,
-          config: mergedConfig as Record<string, string>,
-        },
+      const row = await upsertAuthConfig(upperProvider, {
+        enabled: body.enabled,
+        config: body.config ? mergedConfig : undefined,
       })
 
       // Invalidate OIDC client cache when OIDC config changes

--- a/charts/roomer/templates/configmap.yaml
+++ b/charts/roomer/templates/configmap.yaml
@@ -6,21 +6,21 @@ metadata:
   labels:
     {{- include "roomer.labels" . | nindent 4 }}
 data:
-  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
-  PORT: "3001"
-  HOST: "0.0.0.0"
-  CORS_ORIGIN: {{ .Values.config.corsOrigin | quote }}
-  APP_URL: {{ .Values.config.appUrl | quote }}
-  API_PUBLIC_URL: {{ .Values.config.apiPublicUrl | quote }}
-  COOKIE_SECURE: {{ .Values.config.cookieSecure | quote }}
-  TRUST_PROXY: {{ .Values.config.trustProxy | quote }}
-  ALLOW_BEARER_AUTH: {{ .Values.config.allowBearerAuth | quote }}
-  SWAGGER_ENABLED: {{ .Values.config.swaggerEnabled | quote }}
-  SMTP_HOST: {{ .Values.config.smtpHost | quote }}
-  SMTP_PORT: {{ .Values.config.smtpPort | quote }}
-  SMTP_SECURE: {{ .Values.config.smtpSecure | quote }}
-  EMAIL_FROM: {{ .Values.config.emailFrom | quote }}
-  FILE_STORAGE_PATH: "/app/uploads"
-  MAX_FILE_SIZE_MB: {{ .Values.config.maxFileSizeMb | quote }}
-  SEED_ADMIN_EMAIL: {{ .Values.config.seedAdminEmail | quote }}
-  SEED_DEMO_DATA: {{ .Values.config.seedDemoData | quote }}
+  ROOMER_NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  ROOMER_PORT: "3001"
+  ROOMER_HOST: "0.0.0.0"
+  ROOMER_CORS_ORIGIN: {{ .Values.config.corsOrigin | quote }}
+  ROOMER_APP_URL: {{ .Values.config.appUrl | quote }}
+  ROOMER_API_PUBLIC_URL: {{ .Values.config.apiPublicUrl | quote }}
+  ROOMER_COOKIE_SECURE: {{ .Values.config.cookieSecure | quote }}
+  ROOMER_TRUST_PROXY: {{ .Values.config.trustProxy | quote }}
+  ROOMER_ALLOW_BEARER_AUTH: {{ .Values.config.allowBearerAuth | quote }}
+  ROOMER_SWAGGER_ENABLED: {{ .Values.config.swaggerEnabled | quote }}
+  ROOMER_SMTP_HOST: {{ .Values.config.smtpHost | quote }}
+  ROOMER_SMTP_PORT: {{ .Values.config.smtpPort | quote }}
+  ROOMER_SMTP_SECURE: {{ .Values.config.smtpSecure | quote }}
+  ROOMER_EMAIL_FROM: {{ .Values.config.emailFrom | quote }}
+  ROOMER_FILE_STORAGE_PATH: "/app/uploads"
+  ROOMER_MAX_FILE_SIZE_MB: {{ .Values.config.maxFileSizeMb | quote }}
+  ROOMER_SEED_ADMIN_EMAIL: {{ .Values.config.seedAdminEmail | quote }}
+  ROOMER_SEED_DEMO_DATA: {{ .Values.config.seedDemoData | quote }}

--- a/charts/roomer/templates/secret.yaml
+++ b/charts/roomer/templates/secret.yaml
@@ -8,18 +8,19 @@ metadata:
     {{- include "roomer.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  DATABASE_URL: {{ include "roomer.databaseUrl" . | quote }}
-  SESSION_SECRET: {{ required "secrets.sessionSecret is required (min 32 chars — generate with: openssl rand -hex 32)" .Values.secrets.sessionSecret | quote }}
+  ROOMER_DATABASE_URL: {{ include "roomer.databaseUrl" . | quote }}
+  ROOMER_SESSION_SECRET: {{ required "secrets.sessionSecret is required (min 32 chars — generate with: openssl rand -hex 32)" .Values.secrets.sessionSecret | quote }}
+  ROOMER_ENCRYPTION_KEY: {{ required "secrets.encryptionKey is required (64 hex chars — generate with: openssl rand -hex 32)" .Values.secrets.encryptionKey | quote }}
   {{- if .Values.secrets.smtpUser }}
-  SMTP_USER: {{ .Values.secrets.smtpUser | quote }}
+  ROOMER_SMTP_USER: {{ .Values.secrets.smtpUser | quote }}
   {{- end }}
   {{- if .Values.secrets.smtpPass }}
-  SMTP_PASS: {{ .Values.secrets.smtpPass | quote }}
+  ROOMER_SMTP_PASS: {{ .Values.secrets.smtpPass | quote }}
   {{- end }}
   {{- if .Values.secrets.seedAdminPassword }}
-  SEED_ADMIN_PASSWORD: {{ .Values.secrets.seedAdminPassword | quote }}
+  ROOMER_SEED_ADMIN_PASSWORD: {{ .Values.secrets.seedAdminPassword | quote }}
   {{- end }}
   {{- if .Values.secrets.seedUserPassword }}
-  SEED_USER_PASSWORD: {{ .Values.secrets.seedUserPassword | quote }}
+  ROOMER_SEED_USER_PASSWORD: {{ .Values.secrets.seedUserPassword | quote }}
   {{- end }}
 {{- end }}

--- a/charts/roomer/values.yaml
+++ b/charts/roomer/values.yaml
@@ -119,6 +119,11 @@ secrets:
   # Required — minimum 32 characters (openssl rand -hex 32)
   sessionSecret: ""
 
+  # Required — 64 hex characters (32 bytes) for AES-256-GCM encryption of sensitive
+  # database fields (OAuth client secrets, LDAP bind credentials).
+  # Generate with: openssl rand -hex 32
+  encryptionKey: ""
+
   smtpUser: ""
   smtpPass: ""
 

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -38,23 +38,31 @@ services:
         condition: service_healthy
     environment:
       NODE_ENV: production
-      DATABASE_URL: postgresql://${POSTGRES_USER:-roomer}:${POSTGRES_PASSWORD:-roomer}@postgres:5432/${POSTGRES_DB:-roomer}
-      # Generate a strong secret: openssl rand -hex 32
-      SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
-      PORT: "3001"
-      HOST: "0.0.0.0"
-      CORS_ORIGIN: ${APP_ORIGIN:-http://localhost}
-      COOKIE_SECURE: ${COOKIE_SECURE:-true}
-      TRUST_PROXY: "true"
+      ROOMER_DATABASE_URL: postgresql://${POSTGRES_USER:-roomer}:${POSTGRES_PASSWORD:-roomer}@postgres:5432/${POSTGRES_DB:-roomer}
+      # CHANGE IN PRODUCTION — generate with: openssl rand -hex 32
+      ROOMER_SESSION_SECRET: ${ROOMER_SESSION_SECRET:-00000000000000000000000000000000}
+      # CHANGE IN PRODUCTION — generate with: openssl rand -hex 32
+      ROOMER_ENCRYPTION_KEY: ${ROOMER_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+      ROOMER_PORT: "3001"
+      ROOMER_HOST: "0.0.0.0"
+      ROOMER_CORS_ORIGIN: ${APP_ORIGIN:-http://localhost}
+      ROOMER_COOKIE_SECURE: ${ROOMER_COOKIE_SECURE:-true}
+      ROOMER_TRUST_PROXY: "true"
+      ROOMER_APP_URL: ${APP_ORIGIN:-http://localhost}
+      ROOMER_FILE_STORAGE_PATH: /app/uploads
+      ROOMER_SMTP_HOST: mailpit
+      ROOMER_SMTP_PORT: "1025"
+      ROOMER_SMTP_SECURE: "false"
+      ROOMER_EMAIL_FROM: ${ROOMER_EMAIL_FROM:-noreply@roomer.local}
+      # Admin account — always created on first start.
+      # If ROOMER_SEED_ADMIN_PASSWORD is not set a random password is generated
+      # and printed once to logs — check with: docker compose logs api
+      ROOMER_SEED_ADMIN_EMAIL: ${ROOMER_SEED_ADMIN_EMAIL:-admin@roomer.local}
+      ROOMER_SEED_ADMIN_PASSWORD: ${ROOMER_SEED_ADMIN_PASSWORD:-}
       # Set to true to seed demo buildings, floors, zones, desks and a test user.
-      # The admin user (admin@roomer.local / admin123) is always seeded regardless.
-      SEED_DEMO_DATA: ${SEED_DEMO_DATA:-false}
-      FILE_STORAGE_PATH: /app/uploads
-      SMTP_HOST: mailpit
-      SMTP_PORT: "1025"
-      SMTP_SECURE: "false"
-      EMAIL_FROM: ${EMAIL_FROM:-noreply@roomer.local}
-      APP_URL: ${APP_ORIGIN:-http://localhost}
+      # ROOMER_SEED_USER_PASSWORD works the same way as ROOMER_SEED_ADMIN_PASSWORD.
+      ROOMER_SEED_DEMO_DATA: ${ROOMER_SEED_DEMO_DATA:-false}
+      ROOMER_SEED_USER_PASSWORD: ${ROOMER_SEED_USER_PASSWORD:-}
     volumes:
       - uploads_data:/app/uploads
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,29 +36,31 @@ services:
         condition: service_healthy
     environment:
       NODE_ENV: production
-      DATABASE_URL: postgresql://${POSTGRES_USER:-roomer}:${POSTGRES_PASSWORD:-roomer}@postgres:5432/${POSTGRES_DB:-roomer}
-      # Generate a strong secret: openssl rand -hex 32
-      SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
-      PORT: "3001"
-      HOST: "0.0.0.0"
-      CORS_ORIGIN: ${APP_ORIGIN:-http://localhost}
-      COOKIE_SECURE: ${COOKIE_SECURE:-true}
-      TRUST_PROXY: "true"
-      # Admin account (always created on first start).
-      # If SEED_ADMIN_PASSWORD is not set, a random password is generated and
-      # printed once to the API container logs — run: docker compose logs api
-      SEED_ADMIN_EMAIL: ${SEED_ADMIN_EMAIL:-admin@roomer.local}
-      SEED_ADMIN_PASSWORD: ${SEED_ADMIN_PASSWORD:-}
+      ROOMER_DATABASE_URL: postgresql://${POSTGRES_USER:-roomer}:${POSTGRES_PASSWORD:-roomer}@postgres:5432/${POSTGRES_DB:-roomer}
+      # CHANGE IN PRODUCTION — generate with: openssl rand -hex 32
+      ROOMER_SESSION_SECRET: ${ROOMER_SESSION_SECRET:-00000000000000000000000000000000}
+      # CHANGE IN PRODUCTION — generate with: openssl rand -hex 32
+      ROOMER_ENCRYPTION_KEY: ${ROOMER_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+      ROOMER_PORT: "3001"
+      ROOMER_HOST: "0.0.0.0"
+      ROOMER_CORS_ORIGIN: ${APP_ORIGIN:-http://localhost}
+      ROOMER_COOKIE_SECURE: ${ROOMER_COOKIE_SECURE:-true}
+      ROOMER_TRUST_PROXY: "true"
+      ROOMER_APP_URL: ${APP_ORIGIN:-http://localhost}
+      ROOMER_FILE_STORAGE_PATH: /app/uploads
+      ROOMER_SMTP_HOST: mailpit
+      ROOMER_SMTP_PORT: "1025"
+      ROOMER_SMTP_SECURE: "false"
+      ROOMER_EMAIL_FROM: ${ROOMER_EMAIL_FROM:-noreply@roomer.local}
+      # Admin account — always created on first start.
+      # If ROOMER_SEED_ADMIN_PASSWORD is not set a random password is generated
+      # and printed once to logs — check with: docker compose logs api
+      ROOMER_SEED_ADMIN_EMAIL: ${ROOMER_SEED_ADMIN_EMAIL:-admin@roomer.local}
+      ROOMER_SEED_ADMIN_PASSWORD: ${ROOMER_SEED_ADMIN_PASSWORD:-}
       # Set to true to seed demo buildings, floors, zones, desks and a test user.
-      # SEED_USER_PASSWORD works the same way as SEED_ADMIN_PASSWORD.
-      SEED_DEMO_DATA: ${SEED_DEMO_DATA:-false}
-      SEED_USER_PASSWORD: ${SEED_USER_PASSWORD:-}
-      FILE_STORAGE_PATH: /app/uploads
-      SMTP_HOST: mailpit
-      SMTP_PORT: "1025"
-      SMTP_SECURE: "false"
-      EMAIL_FROM: ${EMAIL_FROM:-noreply@roomer.local}
-      APP_URL: ${APP_ORIGIN:-http://localhost}
+      # ROOMER_SEED_USER_PASSWORD works the same way as ROOMER_SEED_ADMIN_PASSWORD.
+      ROOMER_SEED_DEMO_DATA: ${ROOMER_SEED_DEMO_DATA:-false}
+      ROOMER_SEED_USER_PASSWORD: ${ROOMER_SEED_USER_PASSWORD:-}
     volumes:
       - uploads_data:/app/uploads
     expose:

--- a/scripts/rotate-encryption-key.ts
+++ b/scripts/rotate-encryption-key.ts
@@ -1,0 +1,113 @@
+/**
+ * Offline key rotation script for AuthConfig encrypted fields.
+ *
+ * Usage:
+ *   ROTATE_OLD_KEY=<64-hex> ROTATE_NEW_KEY=<64-hex> \
+ *   DATABASE_URL=<url> npx ts-node scripts/rotate-encryption-key.ts
+ *
+ * Or with ROOMER_ prefix:
+ *   ROOMER_ROTATE_OLD_KEY=<64-hex> ROOMER_ROTATE_NEW_KEY=<64-hex> \
+ *   ROOMER_DATABASE_URL=<url> npx ts-node scripts/rotate-encryption-key.ts
+ *
+ * Steps:
+ *   1. Stop the API (or ensure no writes happen during rotation).
+ *   2. Run this script with the old and new keys.
+ *   3. Update ROOMER_ENCRYPTION_KEY in your env to the new key.
+ *   4. Restart the API.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+import { Pool } from 'pg'
+
+const r = (name: string): string | undefined =>
+  process.env[`ROOMER_${name}`] ?? process.env[name]
+
+const OLD_KEY_HEX = r('ROTATE_OLD_KEY')
+const NEW_KEY_HEX = r('ROTATE_NEW_KEY')
+const DB_URL = r('DATABASE_URL')
+
+if (!OLD_KEY_HEX || !NEW_KEY_HEX || !DB_URL) {
+  console.error('Required: ROTATE_OLD_KEY, ROTATE_NEW_KEY, DATABASE_URL (or ROOMER_ prefixed)')
+  process.exit(1)
+}
+if (!/^[0-9a-f]{64}$/.test(OLD_KEY_HEX) || !/^[0-9a-f]{64}$/.test(NEW_KEY_HEX)) {
+  console.error('Keys must be exactly 64 lowercase hex characters (32 bytes)')
+  process.exit(1)
+}
+
+const OLD_KEY = Buffer.from(OLD_KEY_HEX, 'hex')
+const NEW_KEY = Buffer.from(NEW_KEY_HEX, 'hex')
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_BYTES = 12
+const TAG_BYTES = 16
+
+function decryptWithKey(envelope: string, key: Buffer): string {
+  if (!envelope.startsWith('enc:v1:')) throw new Error('Not an encrypted envelope')
+  const payload = Buffer.from(envelope.slice(7), 'base64')
+  const iv = payload.subarray(0, IV_BYTES)
+  const tag = payload.subarray(payload.length - TAG_BYTES)
+  const ciphertext = payload.subarray(IV_BYTES, payload.length - TAG_BYTES)
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+  return decipher.update(ciphertext) + decipher.final('utf8')
+}
+
+function encryptWithKey(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_BYTES)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return `enc:v1:${Buffer.concat([iv, ciphertext, tag]).toString('base64')}`
+}
+
+async function main() {
+  const pool = new Pool({ connectionString: DB_URL })
+
+  try {
+    const { rows } = await pool.query<{ id: string; config: unknown }>(
+      'SELECT id, config FROM "AuthConfig"',
+    )
+
+    console.log(`Found ${rows.length} AuthConfig row(s)`)
+    let rotated = 0
+    let skipped = 0
+
+    for (const row of rows) {
+      const raw = typeof row.config === 'string' ? row.config : JSON.stringify(row.config)
+
+      if (!raw.startsWith('enc:v1:')) {
+        console.log(`  [${row.id}] plaintext — skipping (run backfill first or encrypt manually)`)
+        skipped++
+        continue
+      }
+
+      let plaintext: string
+      try {
+        plaintext = decryptWithKey(raw, OLD_KEY)
+      } catch {
+        console.error(`  [${row.id}] failed to decrypt with old key — skipping`)
+        skipped++
+        continue
+      }
+
+      const reEncrypted = encryptWithKey(plaintext, NEW_KEY)
+
+      await pool.query('UPDATE "AuthConfig" SET config = $1 WHERE id = $2', [
+        reEncrypted,
+        row.id,
+      ])
+      console.log(`  [${row.id}] rotated`)
+      rotated++
+    }
+
+    console.log(`\nDone. Rotated: ${rotated}, skipped: ${skipped}`)
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- **#93** — `ROOMER_` prefixed env var namespace across all config (API, Docker Compose, Helm chart), backward-compatible with unprefixed names, fail-fast Zod validation on startup
- **#94** — AES-256-GCM encryption at rest for `AuthConfig.config` (OIDC `clientSecret`, LDAP `bindCredentials`, SAML config) using `ROOMER_ENCRYPTION_KEY`; includes offline key rotation script at `scripts/rotate-encryption-key.ts`

## Commits

1. `feat: ROOMER_ env namespace with backward-compatible fallback (#93)` — `env.ts` + `seed.ts`
2. `feat: AES-256-GCM encryption at rest for AuthConfig secrets (#94)` — `encryption.ts`, `prisma.ts`, auth lib updates, `rotate-encryption-key.ts`
3. `chore: rename all container env vars to ROOMER_ prefix` — Docker Compose + Helm chart
4. `chore: update .env.example files for ROOMER_ namespace`

## Breaking changes

- Helm deployments must now supply `secrets.encryptionKey` (64 hex chars — `openssl rand -hex 32`)
- Root `.env` and Docker Compose vars renamed to `ROOMER_` prefix (old unprefixed names still work in the API itself)

## Test plan

- [ ] `helm install` fails without `secrets.encryptionKey` set
- [ ] API starts and passes health check with valid key
- [ ] Configure an OIDC or LDAP provider via settings UI
- [ ] Query `SELECT config FROM "AuthConfig"` in Postgres — value should start with `enc:v1:`
- [ ] Restart API — auth provider still works (decrypt on read confirmed)
- [ ] Run `scripts/rotate-encryption-key.ts` with old/new keys — rows re-encrypted, API still works after key swap