### PR TITLE
fix: prisma.config.ts reads ROOMER_DATABASE_URL for migrations

### DIFF
--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -2,13 +2,16 @@ import { defineConfig } from 'prisma/config'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { Pool } from 'pg'
 
+const dbUrl = process.env['ROOMER_DATABASE_URL'] ?? process.env['DATABASE_URL']
+
 export default defineConfig({
   datasource: {
-    url: process.env['DATABASE_URL']!,
+    url: dbUrl!,
   },
   migrate: {
     async adapter(env: NodeJS.ProcessEnv) {
-      const pool = new Pool({ connectionString: env['DATABASE_URL'] })
+      const url = env['ROOMER_DATABASE_URL'] ?? env['DATABASE_URL']
+      const pool = new Pool({ connectionString: url })
       return new PrismaPg(pool)
     },
   },


### PR DESCRIPTION
## Summary

`prisma.config.ts` was only reading `DATABASE_URL`, but Helm deployments inject `ROOMER_DATABASE_URL` (no unprefixed fallback in the secret). This caused `prisma migrate deploy` to fail on container startup with:

```
Error: The datasource.url property is required in your Prisma config file when using prisma migrate deploy.
```

## Fix

Both `datasource.url` and the `migrate.adapter` factory now resolve `ROOMER_DATABASE_URL ?? DATABASE_URL`, matching the pattern used everywhere else in the codebase.

## Deploy note

After merging, re-push the `v0.3.5` tag to trigger a clean image rebuild without creating a new release version.