### PR TITLE
chore: sync Helm Chart.yaml appVersion with release-please

### DIFF
--- a/charts/roomer/Chart.yaml
+++ b/charts/roomer/Chart.yaml
@@ -3,7 +3,7 @@ name: roomer
 description: Self-hosted workspace booking platform
 type: application
 version: 0.1.0
-appVersion: "0.3.2"
+appVersion: "0.3.5"
 keywords:
   - roomer
   - workspace

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,15 @@
   "release-type": "node",
   "include-component-in-tag": false,
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "charts/roomer/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ]
+    }
   },
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary

- Bumps `charts/roomer/Chart.yaml` `appVersion` to `0.3.5` (was stale at `0.3.2`)
- Adds `extra-files` entry to `release-please-config.json` so future releases automatically update `appVersion` — no more manual drift