### PR TITLE
feat: auto-complete past bookings via pg-boss cron job

### DIFF
--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -269,6 +269,18 @@ async function handleExpireQueueEntries(): Promise<void> {
   process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Expired queue entries', count: expired.length }) + '\n')
 }
 
+// ─── Worker: auto-complete-bookings (cron every 30 min) ──────────────────────
+
+async function handleAutoCompleteBookings(): Promise<void> {
+  const result = await prisma.booking.updateMany({
+    where: { status: 'CONFIRMED', endsAt: { lt: new Date() } },
+    data: { status: 'COMPLETED' },
+  })
+  if (result.count > 0) {
+    process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Auto-completed past bookings', count: result.count }) + '\n')
+  }
+}
+
 // ─── Worker: expire-claim-deadlines (cron every 5 min) ───────────────────────
 
 async function handleExpireClaimDeadlines(): Promise<void> {
@@ -345,6 +357,7 @@ export async function startQueue(): Promise<void> {
   await b.createQueue('expire-queue-entries')
   await b.createQueue('expire-claim-deadlines')
   await b.createQueue('prune-revoked-tokens')
+  await b.createQueue('auto-complete-bookings')
 
   await b.work<NotificationJobData>('send-notification', handleSendNotification)
 
@@ -357,6 +370,11 @@ export async function startQueue(): Promise<void> {
     await handleExpireClaimDeadlines()
   })
   await b.schedule('expire-claim-deadlines', '*/5 * * * *', {})
+
+  await b.work('auto-complete-bookings', async () => {
+    await handleAutoCompleteBookings()
+  })
+  await b.schedule('auto-complete-bookings', '*/30 * * * *', {})
 
   // Prune expired JWT blocklist entries every 30 minutes
   await b.work('prune-revoked-tokens', async () => {


### PR DESCRIPTION
## Summary

- Adds an `auto-complete-bookings` pg-boss worker that runs every 30 minutes
- Finds all `CONFIRMED` bookings where `endsAt < now()` and transitions them to `COMPLETED` in a single `updateMany`
- Logs count per run (silent when nothing to complete)

Closes #89

## Test plan

- [ ] Deploy and wait for next 30-min tick — confirm `CONFIRMED` bookings with past `endsAt` flip to `COMPLETED`
- [ ] Verify no errors in API logs during the job run