### PR TITLE
feat: production observability — /metrics, health probes, x-request-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ The REST API runs on port `3001` by default.
 | `/api/v1/groups` | Group management |
 | `/api/v1/settings` | Organisation settings, auth provider config, SCIM provisioning |
 | `/scim/v2` | SCIM 2.0 provisioning (separate prefix, bearer token auth) |
+| `/health/live` | Liveness probe — always 200 while the process is running |
+| `/health/ready` | Readiness probe — 200 when the DB is reachable, 503 otherwise |
+| `/metrics` | Prometheus metrics (enabled via `ROOMER_METRICS_ENABLED=true`) |
 
 ---
 
@@ -304,6 +307,7 @@ All API environment variables. Every variable accepts a `ROOMER_` prefix (e.g. `
 | `TRUST_PROXY` | `false` in dev | Trust `X-Forwarded-For` headers |
 | `ALLOW_BEARER_AUTH` | `true` in dev | Accept `Authorization: Bearer` tokens |
 | `SWAGGER_ENABLED` | `true` in dev | Expose Swagger UI at `/docs` |
+| `ROOMER_METRICS_ENABLED` | `false` | Set to `true` to expose a Prometheus `/metrics` endpoint. Unauthenticated — protect at the network/ingress level. |
 | `FILE_STORAGE_PATH` | `./uploads` | Directory for floor plan images |
 | `MAX_FILE_SIZE_MB` | `20` | Maximum upload size |
 | `API_PUBLIC_URL` | `http://localhost:3001` | Public URL of the API — shown in the SCIM settings panel as the endpoint base URL |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,8 +25,6 @@
     "@node-saml/node-saml": "^5.1.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "pg": "^8.12.0",
-    "prisma": "^7.8.0",
     "@roomer/shared": "workspace:*",
     "bcryptjs": "^3.0.3",
     "connect-pg-simple": "^10.0.0",
@@ -37,7 +35,10 @@
     "ldapjs": "^3.0.7",
     "nodemailer": "^8.0.6",
     "openid-client": "^6.8.3",
+    "pg": "^8.12.0",
     "pg-boss": "^12.18.0",
+    "prisma": "^7.8.0",
+    "prom-client": "^15.1.3",
     "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
@@ -48,8 +49,8 @@
     "@types/ldapjs": "^3.0.6",
     "@types/node": "^25.6.0",
     "@types/nodemailer": "^8.0.0",
-    "pino-pretty": "^13.1.3",
     "@types/pg": "^8.11.6",
+    "pino-pretty": "^13.1.3",
     "tsx": "^4.15.0",
     "typescript": "^6.0.3"
   }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,9 @@ import { importRoutes } from './routes/import'
 import { scimRoutes } from './routes/scim'
 import { subscriptionRoutes } from './routes/subscriptions'
 import { getBoss } from './lib/queue'
+import { prisma } from './lib/prisma'
+import { register, httpRequestDuration, setupMetrics } from './lib/metrics'
+import { randomUUID } from 'crypto'
 
 export async function buildApp(): Promise<FastifyInstance> {
   const fastify = Fastify({
@@ -183,6 +186,28 @@ export async function buildApp(): Promise<FastifyInstance> {
     { prefix: '/api/v1/auth' },
   )
 
+  // ─── x-request-id propagation ─────────────────────────────────────────────
+  fastify.addHook('onRequest', (_request, reply, done) => {
+    const existing = _request.headers['x-request-id']
+    const id = (typeof existing === 'string' && existing.length > 0) ? existing : randomUUID()
+    reply.header('x-request-id', id)
+    done()
+  })
+
+  // ─── Metrics instrumentation ───────────────────────────────────────────────
+  if (env.METRICS_ENABLED) {
+    setupMetrics()
+    fastify.addHook('onRequest', (request, _reply, done) => {
+      ;(request as unknown as Record<string, unknown>)['_metricsTimer'] = httpRequestDuration.startTimer()
+      done()
+    })
+    fastify.addHook('onResponse', (request, reply, done) => {
+      const timer = (request as unknown as Record<string, unknown>)['_metricsTimer'] as ((labels: Record<string, string>) => void) | undefined
+      timer?.({ method: request.method, route: request.routeOptions?.url ?? request.url, status_code: String(reply.statusCode) })
+      done()
+    })
+  }
+
   // ─── Routes ────────────────────────────────────────────────────────────────
   await fastify.register(buildingRoutes, { prefix: '/api/v1/buildings' })
   await fastify.register(floorRoutes, { prefix: '/api/v1/floors' })
@@ -201,10 +226,40 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(subscriptionRoutes, { prefix: '/api/v1/subscriptions' })
   await fastify.register(scimRoutes, { prefix: '/scim/v2' })
 
-  // ─── Health check ──────────────────────────────────────────────────────────
-  fastify.get('/health', async (_request, reply) => {
-    return reply.status(200).send({ status: 'ok', timestamp: new Date().toISOString() })
+  // ─── Health checks ─────────────────────────────────────────────────────────
+  // /health/live — process is running (Kubernetes liveness probe)
+  fastify.get('/health/live', { config: { rateLimit: false } }, async (_request, reply) => {
+    return reply.status(200).send({ status: 'ok' })
   })
+
+  // /health/ready — DB is reachable (Kubernetes readiness probe)
+  fastify.get('/health/ready', { config: { rateLimit: false } }, async (_request, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`
+      return reply.status(200).send({ status: 'ok', db: 'ok' })
+    } catch (err) {
+      fastify.log.error(err, 'health/ready check failed')
+      return reply.status(503).send({ status: 'error', db: 'error' })
+    }
+  })
+
+  // /health — alias for /health/ready (backwards compatibility)
+  fastify.get('/health', { config: { rateLimit: false } }, async (_request, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`
+      return reply.status(200).send({ status: 'ok', timestamp: new Date().toISOString() })
+    } catch {
+      return reply.status(503).send({ status: 'error' })
+    }
+  })
+
+  // ─── Prometheus metrics ────────────────────────────────────────────────────
+  if (env.METRICS_ENABLED) {
+    fastify.get('/metrics', { config: { rateLimit: false } }, async (_request, reply) => {
+      const content = await register.metrics()
+      return reply.status(200).header('Content-Type', register.contentType).send(content)
+    })
+  }
 
   // ─── Global error handler ──────────────────────────────────────────────────
   fastify.setErrorHandler((error: FastifyError | Error, _request, reply) => {

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -47,6 +47,12 @@ const envSchema = z.object({
   SWAGGER_ENABLED: z.string()
     .default(isProd ? 'false' : 'true')
     .transform((v) => v === 'true'),
+  // Set to "true" to expose a Prometheus /metrics endpoint.
+  // Disabled by default — enable in environments where a scraper is configured.
+  // Protect this endpoint at the network/ingress level; it is unauthenticated.
+  METRICS_ENABLED: z.string()
+    .default('false')
+    .transform((v) => v === 'true'),
   FILE_STORAGE_PATH: z.string().default('./uploads'),
   MAX_FILE_SIZE_MB: z.coerce.number().default(20),
   SMTP_HOST: z.string().default('localhost'),
@@ -81,6 +87,7 @@ const parsed = envSchema.safeParse({
   TRUST_PROXY:            r('TRUST_PROXY'),
   ALLOW_BEARER_AUTH:      r('ALLOW_BEARER_AUTH'),
   SWAGGER_ENABLED:        r('SWAGGER_ENABLED'),
+  METRICS_ENABLED:        r('METRICS_ENABLED'),
   FILE_STORAGE_PATH:      r('FILE_STORAGE_PATH'),
   MAX_FILE_SIZE_MB:       r('MAX_FILE_SIZE_MB'),
   SMTP_HOST:              r('SMTP_HOST'),

--- a/apps/api/src/lib/metrics.ts
+++ b/apps/api/src/lib/metrics.ts
@@ -1,0 +1,15 @@
+import { Registry, collectDefaultMetrics, Histogram } from 'prom-client'
+
+export const register = new Registry()
+
+export const httpRequestDuration = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  registers: [register],
+})
+
+export function setupMetrics(): void {
+  collectDefaultMetrics({ register })
+}

--- a/charts/roomer/templates/configmap.yaml
+++ b/charts/roomer/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
   ROOMER_TRUST_PROXY: {{ .Values.config.trustProxy | quote }}
   ROOMER_ALLOW_BEARER_AUTH: {{ .Values.config.allowBearerAuth | quote }}
   ROOMER_SWAGGER_ENABLED: {{ .Values.config.swaggerEnabled | quote }}
+  ROOMER_METRICS_ENABLED: {{ .Values.config.metricsEnabled | quote }}
   ROOMER_SMTP_HOST: {{ .Values.config.smtpHost | quote }}
   ROOMER_SMTP_PORT: {{ .Values.config.smtpPort | quote }}
   ROOMER_SMTP_SECURE: {{ .Values.config.smtpSecure | quote }}

--- a/charts/roomer/templates/deployment-api.yaml
+++ b/charts/roomer/templates/deployment-api.yaml
@@ -84,13 +84,13 @@ spec:
             {{- end }}
           startupProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: http
             failureThreshold: 30
             periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: http
             initialDelaySeconds: 5
             periodSeconds: 15
@@ -98,7 +98,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/charts/roomer/values.yaml
+++ b/charts/roomer/values.yaml
@@ -85,6 +85,7 @@ config:
   trustProxy: "true"
   allowBearerAuth: "false"
   swaggerEnabled: "false"
+  metricsEnabled: "false"
   smtpHost: ""
   smtpPort: "1025"
   smtpSecure: "false"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -840,6 +843,10 @@ packages:
   '@node-saml/node-saml@5.1.0':
     resolution: {integrity: sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw==}
     engines: {node: '>= 18'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -1828,6 +1835,9 @@ packages:
   better-result@2.8.2:
     resolution: {integrity: sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -2550,6 +2560,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -2823,6 +2837,9 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -3513,6 +3530,8 @@ snapshots:
       xpath: 0.0.34
     transitivePeerDependencies:
       - supports-color
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.127.0': {}
 
@@ -4442,6 +4461,8 @@ snapshots:
 
   better-result@2.8.2: {}
 
+  bintrees@1.0.2: {}
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -5146,6 +5167,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -5415,6 +5441,10 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   thread-stream@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Prometheus `/metrics`** — expose via `ROOMER_METRICS_ENABLED=true` (default off). Includes Node.js default metrics (memory, CPU, event loop) and an HTTP request duration histogram labelled by method, route, and status code. Endpoint is unauthenticated — protect at the network/ingress level in production.
- **Health probes** — `/health/live` (always 200, liveness) and `/health/ready` (`SELECT 1` DB check, 503 on failure, readiness). `/health` kept as a backward-compatible alias for `/health/ready`.
- **`x-request-id` propagation** — echoes an incoming `x-request-id` header or generates a UUID; returned on every response for distributed tracing.

## New env var

| Variable | Default | Description |
|---|---|---|
| `ROOMER_METRICS_ENABLED` | `false` | Set to `true` to expose `/metrics` for Prometheus scraping |

## Test plan

- [ ] `GET /health/live` returns 200
- [ ] `GET /health/ready` returns 200 with DB up, 503 with DB down
- [ ] `GET /metrics` returns 404 without `ROOMER_METRICS_ENABLED=true`; returns Prometheus text format when enabled
- [ ] Responses include `x-request-id` header

Closes #87