### PR TITLE
chore(helm): point web init container at /health/ready instead of /health

### DIFF
--- a/charts/roomer/templates/deployment-web.yaml
+++ b/charts/roomer/templates/deployment-web.yaml
@@ -45,7 +45,7 @@ spec:
             - sh
             - -c
             - |
-              until wget -qO /dev/null http://{{ include "roomer.api.fullname" . }}:3001/health; do
+              until wget -qO /dev/null http://{{ include "roomer.api.fullname" . }}:3001/health/ready; do
                 echo "waiting for api..."; sleep 2
               done
           securityContext: {}


### PR DESCRIPTION
chore: minor fix to helm readiness check endpoint