### PR TITLE
feat: DXF floor plan stroke colour adapts to dark/light mode

### DIFF
--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -341,11 +341,14 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     const contentType = mimeMap[ext] ?? 'application/octet-stream'
 
     // Optional stroke colour override for SVG floor plans (DXF-derived).
-    // Allows the frontend to adapt line colour for dark/light mode without re-uploading.
-    // Only accepted for SVG; validated strictly to a 3- or 6-digit hex colour.
-    const { stroke } = request.query as { stroke?: string }
-    if (stroke !== undefined && !/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(stroke)) {
-      return reply.status(400).send({ error: { message: 'Invalid stroke colour — use a 3- or 6-digit hex value (e.g. #e2e8f0)', code: 'INVALID_PARAM' } })
+    // Accepts a plain 6-character hex string without the # prefix (e.g. stroke=e2e8f0).
+    const { stroke: rawStroke } = request.query as { stroke?: string }
+    let stroke: string | undefined
+    if (rawStroke !== undefined && rawStroke !== '') {
+      if (!/^[0-9a-fA-F]{6}$/.test(rawStroke)) {
+        return reply.status(400).send({ error: { message: 'Invalid stroke colour — provide a 6-character hex string without # (e.g. e2e8f0)', code: 'INVALID_PARAM' } })
+      }
+      stroke = `#${rawStroke}`
     }
 
     if (contentType === 'image/svg+xml' && stroke) {

--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -340,6 +340,25 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     }
     const contentType = mimeMap[ext] ?? 'application/octet-stream'
 
+    // Optional stroke colour override for SVG floor plans (DXF-derived).
+    // Allows the frontend to adapt line colour for dark/light mode without re-uploading.
+    // Only accepted for SVG; validated strictly to a 3- or 6-digit hex colour.
+    const { stroke } = request.query as { stroke?: string }
+    if (stroke !== undefined && !/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(stroke)) {
+      return reply.status(400).send({ error: { message: 'Invalid stroke colour — use a 3- or 6-digit hex value (e.g. #e2e8f0)', code: 'INVALID_PARAM' } })
+    }
+
+    if (contentType === 'image/svg+xml' && stroke) {
+      const raw = await fs.promises.readFile(absPath, 'utf-8')
+      const recolored = raw.replace(/stroke="[^"]*"/g, `stroke="${stroke}"`)
+      reply
+        .header('Content-Type', contentType)
+        .header('Cache-Control', 'public, max-age=86400')
+        .header('Content-Security-Policy', "default-src 'none'")
+        .header('X-Content-Type-Options', 'nosniff')
+      return reply.send(recolored)
+    }
+
     const stream = fs.createReadStream(absPath)
     reply.header('Content-Type', contentType)
     reply.header('Cache-Control', 'public, max-age=86400')

--- a/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
+++ b/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
@@ -166,7 +166,7 @@ export function FloorPlanCanvas({
     const params = new URLSearchParams()
     if (updatedAt) params.set('v', updatedAt)
     // DXF files are served as SVG — request a stroke colour that suits the current theme
-    if (fileType === 'DXF') params.set('stroke', isDark ? '#e2e8f0' : '#334155')
+    if (fileType === 'DXF') params.set('stroke', isDark ? 'e2e8f0' : '334155')
     const qs = params.toString()
     return `/api/v1/floors/${floorId}/floor-plan/image${qs ? `?${qs}` : ''}`
   })()
@@ -323,7 +323,7 @@ export function FloorPlanCanvas({
   // loading, containerRef.current is null when the effect runs ([] deps) and
   // dimensions stays stuck at the initial { 800, 600 } default.
   return (
-    <div className="relative h-full w-full" ref={containerRef} style={{ cursor: isLoading ? 'default' : 'grab' }}>
+    <div className="relative h-full w-full bg-slate-50 dark:bg-slate-900" ref={containerRef} style={{ cursor: isLoading ? 'default' : 'grab' }}>
       {isLoading && (
         <div className="absolute inset-0 z-20 flex items-center justify-center">
           <Skeleton className="h-full w-full" />

--- a/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
+++ b/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
@@ -9,7 +9,25 @@ import { AssetShape } from './AssetShape'
 import { DeskMarker } from './DeskMarker'
 import { useFloorData, useFloorAvailability } from '@/hooks/useFloor'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useThemeStore } from '@/stores/theme'
 import type { AssetWithStatus } from '@/types'
+
+// Resolve whether the UI is currently in dark mode, reacting to both the stored
+// theme preference and the OS-level prefers-color-scheme media query.
+function useIsDarkMode(): boolean {
+  const theme = useThemeStore((s) => s.theme)
+  const [systemDark, setSystemDark] = useState(
+    () => window.matchMedia('(prefers-color-scheme: dark)').matches,
+  )
+  useEffect(() => {
+    if (theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [theme])
+  return theme === 'system' ? systemDark : theme === 'dark'
+}
 
 // Use the bundled worker from pdfjs-dist
 pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl
@@ -140,11 +158,18 @@ export function FloorPlanCanvas({
     setDisplayScale(serverDisplayScale)
   }, [serverDisplayScale])
 
+  const isDark = useIsDarkMode()
   const updatedAt = floorData?.floorPlan?.updatedAt
-  const floorPlanUrl = updatedAt
-    ? `/api/v1/floors/${floorId}/floor-plan/image?v=${encodeURIComponent(updatedAt)}`
-    : `/api/v1/floors/${floorId}/floor-plan/image`
   const fileType = floorData?.floorPlan?.fileType
+
+  const floorPlanUrl = (() => {
+    const params = new URLSearchParams()
+    if (updatedAt) params.set('v', updatedAt)
+    // DXF files are served as SVG — request a stroke colour that suits the current theme
+    if (fileType === 'DXF') params.set('stroke', isDark ? '#e2e8f0' : '#334155')
+    const qs = params.toString()
+    return `/api/v1/floors/${floorId}/floor-plan/image${qs ? `?${qs}` : ''}`
+  })()
   const hasFloorPlan = Boolean(floorData?.floorPlan)
 
   const [bgImage, bgStatus] = useFloorPlanImage(


### PR DESCRIPTION
## Summary

- Adds an optional `?stroke=<6-char-hex>` query param to `GET /floors/:id/floor-plan/image` — when the rendered file is an SVG the stroke colour is rewritten on-the-fly before serving
- `FloorPlanCanvas` detects the current theme (including OS-level `prefers-color-scheme` for the `system` setting) and appends `stroke=e2e8f0` in dark mode or `stroke=334155` in light mode for DXF floor plans
- Canvas container gets an explicit `bg-slate-50 dark:bg-slate-900` background so lines are always legible regardless of parent element styling

## Test plan

- [x] Upload a DXF floor plan, view it in light mode — dark lines visible on light background
- [x] Switch to dark mode — lines become light/white, visible on dark canvas background
- [x] Hit `/api/v1/floors/:id/floor-plan/image?stroke=FF0000` directly in a logged-in browser tab — SVG returns with red lines
- [x] Pass an invalid stroke value (e.g. `stroke=ZZZZZZ`) — API returns 400
- [x] Non-DXF floor plans (image/PDF) are unaffected — no `stroke` param appended