### PR TITLE
feat: configurable navigation styles with draggable floating island

### DIFF
--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -31,6 +31,7 @@ const brandingSchema = z.object({
   primaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional().nullable(),
   primaryColorDark: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional().nullable(),
   borderRadius: z.enum(['sharp', 'medium', 'large']).optional().nullable(),
+  navStyle: z.enum(['sidebar', 'topbar', 'floating', 'rail']).optional().nullable(),
   headerBanner: bannerSchema.optional(),
   footerBanner: bannerSchema.optional(),
 })

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -2,16 +2,17 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
+import { SidebarNav } from './navStyles/SidebarNav'
+import { TopNav } from './navStyles/TopNav'
+import { FloatingNav } from './navStyles/FloatingNav'
+import { RailNav } from './navStyles/RailNav'
 import { cn } from '@/lib/utils'
 import { useBranding } from '@/hooks/useBranding'
 
 function Banner({ text, bgColor, textColor }: { text: string; bgColor: string; textColor: string }) {
   if (!text) return null
   return (
-    <div
-      className="px-4 py-1.5 text-center text-sm font-medium"
-      style={{ backgroundColor: bgColor, color: textColor }}
-    >
+    <div className="px-4 py-1.5 text-center text-sm font-medium" style={{ backgroundColor: bgColor, color: textColor }}>
       {text}
     </div>
   )
@@ -21,27 +22,68 @@ export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const branding = useBranding()
 
+  const navStyle = branding?.navStyle ?? 'sidebar'
   const headerBanner = branding?.headerBanner?.enabled ? branding.headerBanner : null
   const footerBanner = branding?.footerBanner?.enabled ? branding.footerBanner : null
 
+  // Floating nav has its own layout structure (no traditional sidebar/topbar)
+  if (navStyle === 'floating') {
+    return (
+      <div className="flex h-screen flex-col overflow-hidden bg-background">
+        {headerBanner && <Banner text={headerBanner.text} bgColor={headerBanner.bgColor} textColor={headerBanner.textColor} />}
+        <FloatingNav />
+        <main className="flex-1 overflow-auto pt-10">
+          <Outlet />
+        </main>
+        {footerBanner && <Banner text={footerBanner.text} bgColor={footerBanner.bgColor} textColor={footerBanner.textColor} />}
+      </div>
+    )
+  }
+
+  // Top nav has no sidebar
+  if (navStyle === 'topbar') {
+    return (
+      <div className="flex h-screen flex-col overflow-hidden bg-background">
+        {headerBanner && <Banner text={headerBanner.text} bgColor={headerBanner.bgColor} textColor={headerBanner.textColor} />}
+        <TopNav />
+        <main className="flex-1 overflow-auto">
+          <Outlet />
+        </main>
+        {footerBanner && <Banner text={footerBanner.text} bgColor={footerBanner.bgColor} textColor={footerBanner.textColor} />}
+      </div>
+    )
+  }
+
+  // Rail nav — icon rail replaces the aside, no separate TopBar needed (rail has utilities)
+  if (navStyle === 'rail') {
+    return (
+      <div className="flex h-screen flex-col overflow-hidden bg-background">
+        {headerBanner && <Banner text={headerBanner.text} bgColor={headerBanner.bgColor} textColor={headerBanner.textColor} />}
+        <div className="flex flex-1 overflow-hidden">
+          <RailNav />
+          <main className="flex-1 overflow-auto">
+            <Outlet />
+          </main>
+        </div>
+        {footerBanner && <Banner text={footerBanner.text} bgColor={footerBanner.bgColor} textColor={footerBanner.textColor} />}
+      </div>
+    )
+  }
+
+  // Default: enhanced sidebar
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-background">
-      {headerBanner && (
-        <Banner text={headerBanner.text} bgColor={headerBanner.bgColor} textColor={headerBanner.textColor} />
-      )}
+      {headerBanner && <Banner text={headerBanner.text} bgColor={headerBanner.bgColor} textColor={headerBanner.textColor} />}
 
       <div className="flex flex-1 overflow-hidden">
-        {/* Desktop sidebar */}
-        <aside className="hidden w-60 shrink-0 border-r bg-background md:flex md:flex-col">
-          <Sidebar />
+        {/* Desktop enhanced sidebar */}
+        <aside className="hidden md:flex">
+          <SidebarNav />
         </aside>
 
         {/* Mobile sidebar overlay */}
         {sidebarOpen && (
-          <div
-            className="fixed inset-0 z-40 bg-black/50 md:hidden"
-            onClick={() => setSidebarOpen(false)}
-          />
+          <div className="fixed inset-0 z-40 bg-black/50 md:hidden" onClick={() => setSidebarOpen(false)} />
         )}
 
         {/* Mobile sidebar drawer */}
@@ -54,7 +96,6 @@ export default function Layout() {
           <Sidebar onNavigate={() => setSidebarOpen(false)} />
         </aside>
 
-        {/* Main content */}
         <div className="flex flex-1 flex-col overflow-hidden">
           <TopBar onMenuClick={() => setSidebarOpen((o) => !o)} />
           <main className="flex-1 overflow-auto">
@@ -63,9 +104,7 @@ export default function Layout() {
         </div>
       </div>
 
-      {footerBanner && (
-        <Banner text={footerBanner.text} bgColor={footerBanner.bgColor} textColor={footerBanner.textColor} />
-      )}
+      {footerBanner && <Banner text={footerBanner.text} bgColor={footerBanner.bgColor} textColor={footerBanner.textColor} />}
     </div>
   )
 }

--- a/apps/web/src/components/layout/navStyles/FloatingNav.tsx
+++ b/apps/web/src/components/layout/navStyles/FloatingNav.tsx
@@ -1,0 +1,553 @@
+/**
+ * FloatingNav — fixed logo + two draggable glass-morphism floats.
+ *
+ * 1. Logo           — fixed top-left, pointer-events-none (non-blocking)
+ * 2. Utility float  — notifications, theme, user menu (draggable)
+ * 3. Nav island     — primary navigation (draggable + rotatable via scroll-during-drag)
+ *
+ * Panel positioning uses getBoundingClientRect on the pill element so the
+ * panel always appears adjacent to the pill's visual bounds, even when rotated.
+ * Panel direction adapts based on rotation:
+ *   near-horizontal → above / below   (based on y position)
+ *   near-vertical   → right / left    (based on x position)
+ */
+import { useState, useRef, useEffect } from 'react'
+import { NavLink, useNavigate, useLocation } from 'react-router-dom'
+import {
+  ChevronDown, ChevronRight, Building2, GripHorizontal,
+  LogOut, Settings, User, Sun, Moon, Info, ExternalLink, X,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useNavConfig } from '@/hooks/useNavConfig'
+import { useAuth } from '@/hooks/useAuth'
+import { useThemeStore } from '@/stores/theme'
+import { useBranding } from '@/hooks/useBranding'
+import { brandingApi, buildingsApi } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { NotificationBell } from '../NotificationBell'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
+  DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useQuery } from '@tanstack/react-query'
+
+const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'dev'
+const APP_REPO_URL = import.meta.env.VITE_APP_REPO_URL || ''
+
+const UTIL_KEY = 'roomer-floating-util-pos'
+const NAV_KEY  = 'roomer-floating-nav-pos'
+const ROT_KEY  = 'roomer-floating-nav-rot'
+
+type PanelId  = 'buildings' | 'admin' | 'manager' | null
+type PanelDir = 'above' | 'below' | 'right' | 'left'
+type Pos = { x: number; y: number }
+
+// ── Shared drag hook ──────────────────────────────────────────────────────────
+
+function useDraggable(storageKey: string, getDefault: () => Pos) {
+  const [pos, setPos] = useState<Pos>(() => {
+    try {
+      const p = JSON.parse(localStorage.getItem(storageKey) ?? '') as Pos
+      if (typeof p.x === 'number' && typeof p.y === 'number') return p
+    } catch {}
+    return getDefault()
+  })
+
+  const elRef = useRef<HTMLDivElement>(null)
+  const posRef = useRef(pos)
+  posRef.current = pos
+  const drag = useRef({ active: false, startX: 0, startY: 0, origX: 0, origY: 0 })
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    drag.current = { active: true, startX: e.clientX, startY: e.clientY, origX: posRef.current.x, origY: posRef.current.y }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    e.preventDefault()
+  }
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!drag.current.active) return
+    const { startX, startY, origX, origY } = drag.current
+    setPos({ x: origX + e.clientX - startX, y: origY + e.clientY - startY })
+  }
+
+  const onPointerUp = () => {
+    if (!drag.current.active) return
+    drag.current.active = false
+    setPos((p) => {
+      const rect = elRef.current?.getBoundingClientRect()
+      const clamped: Pos = {
+        x: Math.max(8, Math.min(p.x, window.innerWidth  - (rect?.width  ?? 140) - 8)),
+        y: Math.max(8, Math.min(p.y, window.innerHeight - (rect?.height ?? 44)  - 8)),
+      }
+      localStorage.setItem(storageKey, JSON.stringify(clamped))
+      return clamped
+    })
+  }
+
+  useEffect(() => {
+    const onResize = () => setPos((p) => {
+      const rect = elRef.current?.getBoundingClientRect()
+      return {
+        x: Math.max(8, Math.min(p.x, window.innerWidth  - (rect?.width  ?? 140) - 8)),
+        y: Math.max(8, Math.min(p.y, window.innerHeight - (rect?.height ?? 44)  - 8)),
+      }
+    })
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { pos, elRef, gripProps: { onPointerDown, onPointerMove, onPointerUp } as const }
+}
+
+// ── Panel direction + positioning ─────────────────────────────────────────────
+
+function getPanelDir(rotation: number, pos: Pos): PanelDir {
+  const norm = ((rotation % 360) + 360) % 360
+  const nearVertical = (norm > 45 && norm < 135) || (norm > 225 && norm < 315)
+  if (nearVertical) return pos.x < window.innerWidth / 2 ? 'right' : 'left'
+  return pos.y > window.innerHeight * 0.5 ? 'above' : 'below'
+}
+
+// CSS transform so the panel's anchor corner sits at (left, top) of the fixed element
+const panelTransform: Record<PanelDir, string> = {
+  above: 'translate(-50%, -100%)',
+  below: 'translate(-50%, 0)',
+  right: 'translate(0, -50%)',
+  left:  'translate(-100%, -50%)',
+}
+
+const panelSlide: Record<PanelDir, string> = {
+  above: 'animate-in slide-in-from-bottom-2',
+  below: 'animate-in slide-in-from-top-2',
+  right: 'animate-in slide-in-from-left-2',
+  left:  'animate-in slide-in-from-right-2',
+}
+
+// Compute the fixed anchor point for a panel given the pill's getBoundingClientRect
+function computeAnchor(dir: PanelDir, rect: DOMRect, gap = 8): Pos {
+  switch (dir) {
+    case 'above': return { x: rect.left + rect.width  / 2, y: rect.top    - gap }
+    case 'below': return { x: rect.left + rect.width  / 2, y: rect.bottom + gap }
+    case 'right': return { x: rect.right  + gap,           y: rect.top    + rect.height / 2 }
+    case 'left':  return { x: rect.left   - gap,           y: rect.top    + rect.height / 2 }
+  }
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function FloatingNav() {
+  const { sections, buildingsData } = useNavConfig()
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const branding = useBranding()
+  const { theme, setTheme } = useThemeStore()
+  const [openPanel, setOpenPanel] = useState<PanelId>(null)
+  const [panelState, setPanelState] = useState<{ anchor: Pos; dir: PanelDir } | null>(null)
+  const [aboutOpen, setAboutOpen] = useState(false)
+
+  const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const initials = user?.displayName?.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+  const personalSection  = sections.find((s) => s.id === 'personal')
+  const secondarySection = sections.find((s) => s.id !== 'personal')
+
+  // ── Utility float ─────────────────────────────────────────────────────────
+
+  const util = useDraggable(UTIL_KEY, () => ({ x: Math.max(8, window.innerWidth - 200), y: 16 }))
+
+  // ── Nav float — drag + wheel rotation ────────────────────────────────────
+
+  const [navPos, setNavPos] = useState<Pos>(() => {
+    try {
+      const p = JSON.parse(localStorage.getItem(NAV_KEY) ?? '') as Pos
+      if (typeof p.x === 'number' && typeof p.y === 'number') return p
+    } catch {}
+    return { x: Math.max(8, Math.round(window.innerWidth / 2) - 160), y: window.innerHeight - 80 }
+  })
+
+  const [rotation, setRotation] = useState<number>(() => {
+    try { return Number(localStorage.getItem(ROT_KEY)) || 0 } catch { return 0 }
+  })
+
+  const navRef    = useRef<HTMLDivElement>(null)
+  const pillRef   = useRef<HTMLDivElement>(null)   // tracks visual pill bounds after rotation
+  const panelElRef = useRef<HTMLDivElement | null>(null)
+  const navPosRef  = useRef(navPos)
+  navPosRef.current = navPos
+  const navDrag = useRef({ active: false, startX: 0, startY: 0, origX: 0, origY: 0 })
+
+  const wheelHandler = useRef((e: WheelEvent) => {
+    if (!navDrag.current.active) return
+    e.preventDefault()
+    setRotation((r) => {
+      const next = ((r + (e.deltaY < 0 ? 5 : -5)) % 360 + 360) % 360
+      localStorage.setItem(ROT_KEY, String(next))
+      return next
+    })
+  })
+
+  const closePanel = () => { setOpenPanel(null); setPanelState(null) }
+
+  const onNavGripDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    navDrag.current = { active: true, startX: e.clientX, startY: e.clientY, origX: navPosRef.current.x, origY: navPosRef.current.y }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    e.preventDefault()
+    closePanel()  // dismiss any open panel when dragging starts
+    window.addEventListener('wheel', wheelHandler.current, { passive: false })
+  }
+
+  const onNavGripMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!navDrag.current.active) return
+    const { startX, startY, origX, origY } = navDrag.current
+    setNavPos({ x: origX + e.clientX - startX, y: origY + e.clientY - startY })
+  }
+
+  const onNavGripUp = () => {
+    if (!navDrag.current.active) return
+    navDrag.current.active = false
+    window.removeEventListener('wheel', wheelHandler.current)
+    setNavPos((p) => {
+      const rect = navRef.current?.getBoundingClientRect()
+      const clamped: Pos = {
+        x: Math.max(8, Math.min(p.x, window.innerWidth  - (rect?.width  ?? 320) - 8)),
+        y: Math.max(8, Math.min(p.y, window.innerHeight - (rect?.height ?? 56)  - 8)),
+      }
+      localStorage.setItem(NAV_KEY, JSON.stringify(clamped))
+      return clamped
+    })
+  }
+
+  useEffect(() => {
+    const wh = wheelHandler.current
+    const onResize = () => setNavPos((p) => {
+      const rect = navRef.current?.getBoundingClientRect()
+      return {
+        x: Math.max(8, Math.min(p.x, window.innerWidth  - (rect?.width  ?? 320) - 8)),
+        y: Math.max(8, Math.min(p.y, window.innerHeight - (rect?.height ?? 56)  - 8)),
+      }
+    })
+    window.addEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('wheel', wh)
+    }
+  }, [])
+
+  // ── Panel toggle ──────────────────────────────────────────────────────────
+
+  const togglePanel = (id: PanelId) => {
+    if (openPanel === id) { closePanel(); return }
+    const rect = pillRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const dir = getPanelDir(rotation, navPos)
+    setPanelState({ anchor: computeAnchor(dir, rect), dir })
+    setOpenPanel(id)
+  }
+
+  // Close panel on navigation
+  useEffect(() => { closePanel() }, [location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Close panel on outside click (checks both nav and panel elements)
+  useEffect(() => {
+    if (!openPanel) return
+    const handler = (e: MouseEvent) => {
+      const inNav   = navRef.current?.contains(e.target as Node)
+      const inPanel = panelElRef.current?.contains(e.target as Node)
+      if (!inNav && !inPanel) closePanel()
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [openPanel]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const gripClass = 'cursor-grab active:cursor-grabbing select-none touch-none text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors'
+
+  return (
+    <>
+      {/* ── Logo — fixed top-left, non-blocking ───────────────────────────── */}
+      <div style={{ position: 'fixed', top: 16, left: 16, zIndex: 10, pointerEvents: 'none' }}>
+        {branding?.logoPath ? (
+          <img
+            src={`${brandingApi.getLogoUrl()}?t=${branding.logoPath}`}
+            alt={branding.appName ?? 'Logo'}
+            className="h-6 max-w-[100px] object-contain opacity-70"
+          />
+        ) : (
+          <span className="text-sm font-bold text-foreground/70 select-none">
+            {branding?.appName ?? 'Roomer'}
+          </span>
+        )}
+      </div>
+
+      {/* ── Utility float ─────────────────────────────────────────────────── */}
+      <div ref={util.elRef} style={{ position: 'fixed', left: util.pos.x, top: util.pos.y, zIndex: 50 }}>
+        <div className="flex items-center gap-1 rounded-xl border border-border/60 bg-background/80 px-2 py-1.5 shadow-lg backdrop-blur-xl">
+          <div {...util.gripProps} className={`${gripClass} px-0.5`} title="Drag to reposition">
+            <GripHorizontal className="h-3 w-3" />
+          </div>
+          <div className="mx-0.5 h-5 w-px bg-border/40" />
+          <NotificationBell />
+          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setTheme(isDark ? 'light' : 'dark')}>
+            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 rounded-full p-0">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback className="bg-primary text-primary-foreground text-xs">{initials ?? 'U'}</AvatarFallback>
+                </Avatar>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>
+                <p className="text-sm font-medium">{user?.displayName}</p>
+                <p className="text-xs text-muted-foreground">{user?.email}</p>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => navigate('/profile')}><User className="mr-2 h-4 w-4" />Profile</DropdownMenuItem>
+              {user?.globalRole === 'SUPER_ADMIN' && (
+                <DropdownMenuItem onClick={() => navigate('/admin/settings')}><Settings className="mr-2 h-4 w-4" />Settings</DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setAboutOpen(true)}><Info className="mr-2 h-4 w-4" />About</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={logout} className="text-destructive"><LogOut className="mr-2 h-4 w-4" />Log out</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* ── Nav island ────────────────────────────────────────────────────── */}
+      <div ref={navRef} style={{ position: 'fixed', left: navPos.x, top: navPos.y, zIndex: 50 }}>
+        {/* Pill — rotates; each item counter-rotates to stay upright */}
+        <div
+          ref={pillRef}
+          style={{ transform: `rotate(${rotation}deg)` }}
+          className="flex items-center gap-1 rounded-2xl border border-border/60 bg-background/80 px-3 py-2 shadow-2xl backdrop-blur-xl"
+        >
+          {/* Drag + rotate handle */}
+          <div
+            onPointerDown={onNavGripDown}
+            onPointerMove={onNavGripMove}
+            onPointerUp={onNavGripUp}
+            style={{ transform: `rotate(${-rotation}deg)` }}
+            className={`${gripClass} px-1`}
+            title="Drag to move · Scroll to rotate"
+          >
+            <GripHorizontal className="h-3.5 w-3.5" />
+          </div>
+
+          <div style={{ transform: `rotate(${-rotation}deg)` }} className="mx-0.5 h-6 w-px bg-border/40" />
+
+          {/* Personal nav items */}
+          {personalSection?.items.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center justify-center rounded-xl p-2 transition-all duration-150',
+                  isActive
+                    ? 'bg-primary text-primary-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                )
+              }
+            >
+              <div style={{ transform: `rotate(${-rotation}deg)` }} className="flex flex-col items-center gap-0.5">
+                <item.icon className="h-5 w-5" />
+                <span className="text-[10px] font-medium leading-none">{item.label.replace('My ', '')}</span>
+              </div>
+            </NavLink>
+          ))}
+
+          <div style={{ transform: `rotate(${-rotation}deg)` }} className="mx-1 h-8 w-px bg-border/60" />
+
+          {/* Buildings trigger */}
+          <button
+            onClick={() => togglePanel('buildings')}
+            className={cn(
+              'flex items-center justify-center rounded-xl p-2 transition-all duration-150',
+              openPanel === 'buildings'
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+            )}
+          >
+            <div style={{ transform: `rotate(${-rotation}deg)` }} className="flex flex-col items-center gap-0.5">
+              <Building2 className="h-5 w-5" />
+              <span className="text-[10px] font-medium leading-none">Buildings</span>
+            </div>
+          </button>
+
+          {/* Secondary section trigger (Admin / Manager) */}
+          {secondarySection && (() => {
+            const SecIcon = secondarySection.items[0].icon
+            return (
+              <>
+                <div style={{ transform: `rotate(${-rotation}deg)` }} className="mx-1 h-8 w-px bg-border/60" />
+                <button
+                  onClick={() => togglePanel(secondarySection.id as PanelId)}
+                  className={cn(
+                    'flex items-center justify-center rounded-xl p-2 transition-all duration-150',
+                    openPanel === secondarySection.id
+                      ? 'bg-primary text-primary-foreground shadow-sm'
+                      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                  )}
+                >
+                  <div style={{ transform: `rotate(${-rotation}deg)` }} className="flex flex-col items-center gap-0.5">
+                    <SecIcon className="h-5 w-5" />
+                    <span className="text-[10px] font-medium leading-none">{secondarySection.label}</span>
+                  </div>
+                </button>
+              </>
+            )
+          })()}
+        </div>
+      </div>
+
+      {/* ── Panel — fixed, positioned via getBoundingClientRect ───────────── */}
+      {openPanel && panelState && (
+        <div
+          ref={(el) => { panelElRef.current = el }}
+          style={{
+            position: 'fixed',
+            left: panelState.anchor.x,
+            top: panelState.anchor.y,
+            transform: panelTransform[panelState.dir],
+            zIndex: 51,
+          }}
+        >
+          {openPanel === 'buildings' && (
+            <BuildingsPanel buildingsData={buildingsData} onClose={closePanel} dir={panelState.dir} />
+          )}
+          {openPanel === (secondarySection?.id as PanelId) && secondarySection && (
+            <SectionPanel
+              label={secondarySection.label ?? ''}
+              items={secondarySection.items}
+              onClose={closePanel}
+              dir={panelState.dir}
+            />
+          )}
+        </div>
+      )}
+
+      {/* About dialog */}
+      <Dialog open={aboutOpen} onOpenChange={setAboutOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader><DialogTitle>About Roomer</DialogTitle></DialogHeader>
+          <div className="space-y-3 py-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Version</span>
+              <span className="font-mono font-medium">{APP_VERSION}</span>
+            </div>
+            {APP_REPO_URL && (
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Source</span>
+                <a href={APP_REPO_URL} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-primary hover:underline">
+                  GitHub <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+// ── Sub-panels ────────────────────────────────────────────────────────────────
+
+function BuildingsPanel({
+  buildingsData,
+  onClose,
+  dir,
+}: {
+  buildingsData: Array<{ id: string; name: string }>
+  onClose: () => void
+  dir: PanelDir
+}) {
+  const navigate = useNavigate()
+  const [openBuilding, setOpenBuilding] = useState<string | null>(null)
+  const { data } = useQuery({
+    queryKey: ['buildings', openBuilding],
+    queryFn: () => buildingsApi.get(openBuilding!),
+    select: (res) => res.data,
+    enabled: !!openBuilding,
+  })
+
+  return (
+    <div className={cn(
+      'w-56 rounded-2xl border border-border/60 bg-background/90 p-2 shadow-2xl backdrop-blur-xl duration-150',
+      panelSlide[dir],
+    )}>
+      <div className="flex items-center justify-between px-2 py-1 mb-1">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Buildings</span>
+        <button onClick={onClose} className="rounded p-0.5 text-muted-foreground hover:text-foreground">
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {buildingsData.map((b) => (
+        <div key={b.id}>
+          <button
+            onClick={() => setOpenBuilding(openBuilding === b.id ? null : b.id)}
+            className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-foreground hover:bg-accent transition-colors"
+          >
+            <Building2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="flex-1 text-left">{b.name}</span>
+            {openBuilding === b.id
+              ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
+              : <ChevronRight className="h-3 w-3 text-muted-foreground" />}
+          </button>
+          {openBuilding === b.id && data?.floors?.map((floor) => (
+            <button
+              key={floor.id}
+              onClick={() => { navigate(`/floors/${floor.id}`); onClose() }}
+              className="flex w-full items-center pl-8 pr-2 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+            >
+              {floor.name}
+            </button>
+          ))}
+        </div>
+      ))}
+      {buildingsData.length === 0 && <p className="px-2 py-2 text-xs text-muted-foreground">No buildings</p>}
+    </div>
+  )
+}
+
+function SectionPanel({
+  label,
+  items,
+  onClose,
+  dir,
+}: {
+  label: string
+  items: Array<{ to: string; icon: React.ElementType; label: string }>
+  onClose: () => void
+  dir: PanelDir
+}) {
+  const navigate = useNavigate()
+  return (
+    <div className={cn(
+      'w-52 rounded-2xl border border-border/60 bg-background/90 p-2 shadow-2xl backdrop-blur-xl duration-150',
+      panelSlide[dir],
+    )}>
+      <div className="flex items-center justify-between px-2 py-1 mb-1">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{label}</span>
+        <button onClick={onClose} className="rounded p-0.5 text-muted-foreground hover:text-foreground">
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {items.map((item) => (
+        <button
+          key={item.to}
+          onClick={() => { navigate(item.to); onClose() }}
+          className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground hover:bg-accent transition-colors"
+        >
+          <item.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/navStyles/RailNav.tsx
+++ b/apps/web/src/components/layout/navStyles/RailNav.tsx
@@ -1,0 +1,295 @@
+/**
+ * RailNav — 48 px icon rail always visible on the left.
+ * Clicking a rail icon slides out a 220 px navigation panel.
+ * The panel dismisses on outside click or navigation.
+ */
+import { useState, useRef, useEffect } from 'react'
+import { NavLink, useNavigate, useLocation } from 'react-router-dom'
+import { ChevronDown, ChevronRight, Building2, LogOut, Settings, User, Sun, Moon, Info, ExternalLink, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useNavConfig } from '@/hooks/useNavConfig'
+import { useAuth } from '@/hooks/useAuth'
+import { useThemeStore } from '@/stores/theme'
+import { useBranding } from '@/hooks/useBranding'
+import { buildingsApi } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { NotificationBell } from '../NotificationBell'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
+  DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useQuery } from '@tanstack/react-query'
+
+const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'dev'
+const APP_REPO_URL = import.meta.env.VITE_APP_REPO_URL || ''
+
+type RailSection = 'personal' | 'buildings' | 'admin' | 'manager' | null
+
+export function RailNav({ onNavigate }: { onNavigate?: () => void }) {
+  const { sections, buildingsData } = useNavConfig()
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const branding = useBranding()
+  const { theme, setTheme } = useThemeStore()
+  const [activePanel, setActivePanel] = useState<RailSection>(null)
+  const [aboutOpen, setAboutOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const initials = user?.displayName?.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+
+  const personalSection = sections.find((s) => s.id === 'personal')
+  const secondarySection = sections.find((s) => s.id !== 'personal')
+
+  useEffect(() => { setActivePanel(null) }, [location.pathname])
+
+  useEffect(() => {
+    if (!activePanel) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setActivePanel(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [activePanel])
+
+  const toggle = (id: RailSection) => setActivePanel((p) => (p === id ? null : id))
+
+  const handleNavigate = () => {
+    setActivePanel(null)
+    onNavigate?.()
+  }
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div ref={containerRef} className="flex h-full shrink-0">
+        {/* Rail */}
+        <div className="flex w-12 flex-col items-center border-r bg-background py-3 gap-1 shrink-0">
+          {/* Branding mark */}
+          <div className="mb-2 flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xs font-bold select-none">
+            {(branding?.sidebarTitle ?? 'R')[0].toUpperCase()}
+          </div>
+
+          <div className="w-6 border-t mb-1" />
+
+          {/* Personal */}
+          {personalSection && (
+            <RailIcon
+              icon={personalSection.items[0].icon}
+              label="Personal"
+              active={activePanel === 'personal'}
+              onClick={() => toggle('personal')}
+            />
+          )}
+
+          {/* Buildings */}
+          <RailIcon
+            icon={Building2}
+            label="Buildings"
+            active={activePanel === 'buildings'}
+            onClick={() => toggle('buildings')}
+          />
+
+          {/* Admin / Manager */}
+          {secondarySection && (
+            <RailIcon
+              icon={secondarySection.items[0].icon}
+              label={secondarySection.label ?? 'More'}
+              active={activePanel === (secondarySection.id as RailSection)}
+              onClick={() => toggle(secondarySection.id as RailSection)}
+            />
+          )}
+
+          {/* Spacer pushes utilities to bottom */}
+          <div className="flex-1" />
+
+          {/* Utilities */}
+          <NotificationBell />
+          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setTheme(isDark ? 'light' : 'dark')}>
+            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 rounded-full p-0">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback className="bg-primary text-primary-foreground text-xs">{initials ?? 'U'}</AvatarFallback>
+                </Avatar>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="right" align="end" className="w-56">
+              <DropdownMenuLabel>
+                <p className="text-sm font-medium">{user?.displayName}</p>
+                <p className="text-xs text-muted-foreground">{user?.email}</p>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => navigate('/profile')}><User className="mr-2 h-4 w-4" />Profile</DropdownMenuItem>
+              {user?.globalRole === 'SUPER_ADMIN' && (
+                <DropdownMenuItem onClick={() => navigate('/admin/settings')}><Settings className="mr-2 h-4 w-4" />Settings</DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setAboutOpen(true)}><Info className="mr-2 h-4 w-4" />About</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={logout} className="text-destructive"><LogOut className="mr-2 h-4 w-4" />Log out</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* Slide-out panel */}
+        {activePanel && (
+          <div className="w-[220px] flex flex-col border-r bg-background shadow-lg animate-in slide-in-from-left-2 duration-150 overflow-y-auto">
+            <div className="flex items-center justify-between px-3 py-3 border-b shrink-0">
+              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {activePanel === 'personal' ? 'My Space' :
+                 activePanel === 'buildings' ? 'Buildings' :
+                 secondarySection?.label}
+              </span>
+              <button onClick={() => setActivePanel(null)} className="rounded p-0.5 text-muted-foreground hover:text-foreground">
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
+            <nav className="flex-1 p-2 space-y-0.5">
+              {activePanel === 'personal' && personalSection?.items.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  onClick={handleNavigate}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                      isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                    )
+                  }
+                >
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  {item.label}
+                </NavLink>
+              ))}
+
+              {activePanel === 'buildings' && (
+                <BuildingsPanel buildingsData={buildingsData} onNavigate={handleNavigate} />
+              )}
+
+              {activePanel === secondarySection?.id && secondarySection?.items.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  onClick={handleNavigate}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                      isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                    )
+                  }
+                >
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  {item.label}
+                </NavLink>
+              ))}
+            </nav>
+          </div>
+        )}
+      </div>
+
+      <Dialog open={aboutOpen} onOpenChange={setAboutOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader><DialogTitle>About Roomer</DialogTitle></DialogHeader>
+          <div className="space-y-3 py-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Version</span>
+              <span className="font-mono font-medium">{APP_VERSION}</span>
+            </div>
+            {APP_REPO_URL && (
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Source</span>
+                <a href={APP_REPO_URL} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-primary hover:underline">
+                  GitHub <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
+  )
+}
+
+function RailIcon({
+  icon: Icon,
+  label,
+  active,
+  onClick,
+}: {
+  icon: React.ElementType
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onClick}
+          className={cn(
+            'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
+            active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+          )}
+        >
+          <Icon className="h-4.5 w-4.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function BuildingsPanel({
+  buildingsData,
+  onNavigate,
+}: {
+  buildingsData: Array<{ id: string; name: string }>
+  onNavigate: () => void
+}) {
+  const navigate = useNavigate()
+  const [openBuilding, setOpenBuilding] = useState<string | null>(null)
+  const { data } = useQuery({
+    queryKey: ['buildings', openBuilding],
+    queryFn: () => buildingsApi.get(openBuilding!),
+    select: (res) => res.data,
+    enabled: !!openBuilding,
+  })
+
+  return (
+    <div className="space-y-0.5">
+      {buildingsData.map((b) => (
+        <div key={b.id}>
+          <button
+            onClick={() => setOpenBuilding(openBuilding === b.id ? null : b.id)}
+            className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            <Building2 className="h-4 w-4 shrink-0" />
+            <span className="flex-1 text-left">{b.name}</span>
+            {openBuilding === b.id ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+          </button>
+          {openBuilding === b.id && data?.floors?.map((floor) => (
+            <button
+              key={floor.id}
+              onClick={() => { navigate(`/floors/${floor.id}`); onNavigate() }}
+              className="flex w-full items-center pl-9 pr-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
+            >
+              {floor.name}
+            </button>
+          ))}
+        </div>
+      ))}
+      {buildingsData.length === 0 && (
+        <p className="px-3 py-2 text-xs text-muted-foreground">No buildings</p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/navStyles/SidebarNav.tsx
+++ b/apps/web/src/components/layout/navStyles/SidebarNav.tsx
@@ -1,0 +1,231 @@
+import { useState, useEffect } from 'react'
+import { NavLink } from 'react-router-dom'
+import { ChevronDown, ChevronRight, Pin, PinOff, Building2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useNavConfig } from '@/hooks/useNavConfig'
+import { useQuery } from '@tanstack/react-query'
+import { buildingsApi } from '@/lib/api'
+import { useBranding } from '@/hooks/useBranding'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+
+const PINNED_KEY = 'roomer-sidebar-pinned'
+
+interface SidebarNavProps {
+  onNavigate?: () => void
+}
+
+export function SidebarNav({ onNavigate }: SidebarNavProps) {
+  const { sections, buildingsData } = useNavConfig()
+  const branding = useBranding()
+  const [collapsed, setCollapsed] = useState(false)
+  const [pinned, setPinned] = useState(() => localStorage.getItem(PINNED_KEY) !== 'false')
+
+  useEffect(() => {
+    localStorage.setItem(PINNED_KEY, String(pinned))
+    if (!pinned) setCollapsed(true)
+    else setCollapsed(false)
+  }, [pinned])
+
+  const togglePin = () => setPinned((p) => !p)
+
+  const width = collapsed ? 'w-14' : 'w-60'
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div
+        className={cn(
+          'flex h-full flex-col border-r bg-background transition-all duration-200 overflow-hidden shrink-0',
+          width,
+        )}
+        onMouseEnter={() => { if (!pinned) setCollapsed(false) }}
+        onMouseLeave={() => { if (!pinned) setCollapsed(true) }}
+      >
+        {/* Header */}
+        <div className="flex h-14 items-center justify-between px-3 border-b shrink-0">
+          {!collapsed && (
+            <div className="min-w-0">
+              <h2 className="text-sm font-bold text-foreground truncate">{branding?.sidebarTitle ?? 'Roomer'}</h2>
+              <p className="text-xs text-muted-foreground truncate">{branding?.sidebarSubtitle ?? 'Desk Booking'}</p>
+            </div>
+          )}
+          <button
+            onClick={togglePin}
+            className="ml-auto rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shrink-0"
+            title={pinned ? 'Unpin sidebar' : 'Pin sidebar open'}
+          >
+            {pinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
+          </button>
+        </div>
+
+        {/* Nav */}
+        <nav className="flex-1 overflow-y-auto overflow-x-hidden py-3 px-2 space-y-0.5">
+          {sections.map((section) => (
+            <div key={section.id}>
+              {section.label && !collapsed && (
+                <p className="px-3 py-1.5 text-xs font-semibold uppercase text-muted-foreground tracking-wider">
+                  {section.label}
+                </p>
+              )}
+              {section.label && collapsed && <div className="my-1 mx-2 border-t" />}
+              {section.items.map((item) => (
+                <NavItemLink key={item.to} item={item} collapsed={collapsed} onNavigate={onNavigate} />
+              ))}
+            </div>
+          ))}
+
+          {/* Buildings tree */}
+          {!collapsed ? (
+            <BuildingsTree buildingsData={buildingsData} onNavigate={onNavigate} />
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setCollapsed(false)}
+                  className="flex w-full items-center justify-center rounded-lg p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                >
+                  <Building2 className="h-4 w-4 shrink-0" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">Buildings</TooltipContent>
+            </Tooltip>
+          )}
+        </nav>
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function NavItemLink({
+  item,
+  collapsed,
+  onNavigate,
+}: {
+  item: { to: string; icon: React.ElementType; label: string }
+  collapsed: boolean
+  onNavigate?: () => void
+}) {
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <NavLink
+            to={item.to}
+            onClick={onNavigate}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center justify-center rounded-lg p-2 transition-colors',
+                isActive
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+              )
+            }
+          >
+            <item.icon className="h-4 w-4 shrink-0" />
+          </NavLink>
+        </TooltipTrigger>
+        <TooltipContent side="right">{item.label}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <NavLink
+      to={item.to}
+      onClick={onNavigate}
+      className={({ isActive }) =>
+        cn(
+          'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+          isActive
+            ? 'bg-primary text-primary-foreground'
+            : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+        )
+      }
+    >
+      <item.icon className="h-4 w-4 shrink-0" />
+      <span className="truncate">{item.label}</span>
+    </NavLink>
+  )
+}
+
+function BuildingsTree({
+  buildingsData,
+  onNavigate,
+}: {
+  buildingsData: Array<{ id: string; name: string }>
+  onNavigate?: () => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+      >
+        <Building2 className="h-4 w-4 shrink-0" />
+        <span className="flex-1 text-left">Buildings</span>
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+      </button>
+
+      {open && (
+        <div className="ml-7 mt-0.5 space-y-0.5">
+          {buildingsData.map((b) => (
+            <BuildingItem key={b.id} buildingId={b.id} buildingName={b.name} onNavigate={onNavigate} />
+          ))}
+          {buildingsData.length === 0 && (
+            <p className="px-3 py-1 text-xs text-muted-foreground">No buildings</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BuildingItem({
+  buildingId,
+  buildingName,
+  onNavigate,
+}: {
+  buildingId: string
+  buildingName: string
+  onNavigate?: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const { data } = useQuery({
+    queryKey: ['buildings', buildingId],
+    queryFn: () => buildingsApi.get(buildingId),
+    select: (res) => res.data,
+    enabled: open,
+  })
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {buildingName}
+      </button>
+      {open && data && (
+        <div className="ml-5 space-y-0.5">
+          {data.floors?.map((floor) => (
+            <NavLink
+              key={floor.id}
+              to={`/floors/${floor.id}`}
+              onClick={onNavigate}
+              className={({ isActive }) =>
+                cn(
+                  'block rounded px-2 py-1 text-xs transition-colors',
+                  isActive ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:text-foreground',
+                )
+              }
+            >
+              {floor.name}
+            </NavLink>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/navStyles/TopNav.tsx
+++ b/apps/web/src/components/layout/navStyles/TopNav.tsx
@@ -1,0 +1,228 @@
+import { NavLink, useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { ChevronDown, Building2, LogOut, Settings, User, Sun, Moon, Info, ExternalLink } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useNavConfig } from '@/hooks/useNavConfig'
+import { useAuth } from '@/hooks/useAuth'
+import { useThemeStore } from '@/stores/theme'
+import { useBranding } from '@/hooks/useBranding'
+import { brandingApi } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { NotificationBell } from '../NotificationBell'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useQuery } from '@tanstack/react-query'
+import { buildingsApi } from '@/lib/api'
+
+const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'dev'
+const APP_REPO_URL = import.meta.env.VITE_APP_REPO_URL || ''
+
+export function TopNav() {
+  const { sections } = useNavConfig()
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const branding = useBranding()
+  const { theme, setTheme } = useThemeStore()
+  const [aboutOpen, setAboutOpen] = useState(false)
+
+  const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+  const initials = user?.displayName
+    ?.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+
+  const personalSection = sections.find((s) => s.id === 'personal')
+  const secondarySection = sections.find((s) => s.id !== 'personal')
+
+  return (
+    <>
+      <header className="flex h-14 items-center gap-4 border-b bg-background px-4 shrink-0">
+        {/* Logo / App name */}
+        <div className="flex items-center gap-3 shrink-0">
+          {branding?.logoPath ? (
+            <img
+              src={`${brandingApi.getLogoUrl()}?t=${branding.logoPath}`}
+              alt={branding.appName ?? 'Logo'}
+              className="h-7 max-w-[120px] object-contain"
+            />
+          ) : (
+            <span className="text-sm font-bold text-foreground">{branding?.appName ?? 'Roomer'}</span>
+          )}
+        </div>
+
+        <div className="h-5 w-px bg-border shrink-0" />
+
+        {/* Primary nav items */}
+        <nav className="flex items-center gap-1 flex-1 overflow-x-auto">
+          {personalSection?.items.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors',
+                  isActive
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                )
+              }
+            >
+              <item.icon className="h-3.5 w-3.5" />
+              {item.label}
+            </NavLink>
+          ))}
+
+          {/* Buildings dropdown */}
+          <BuildingsDropdown />
+
+          {/* Admin / Manager dropdown */}
+          {secondarySection && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap">
+                  {secondarySection.label}
+                  <ChevronDown className="h-3 w-3" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-48">
+                {secondarySection.items.map((item) => (
+                  <DropdownMenuItem key={item.to} onClick={() => navigate(item.to)}>
+                    <item.icon className="mr-2 h-4 w-4" />
+                    {item.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </nav>
+
+        {/* Right side */}
+        <div className="flex items-center gap-2 shrink-0">
+          <NotificationBell />
+          <Button
+            variant="ghost" size="icon" className="h-9 w-9"
+            title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            onClick={() => setTheme(isDark ? 'light' : 'dark')}
+          >
+            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="relative h-9 w-9 rounded-full p-0">
+                <Avatar className="h-9 w-9">
+                  <AvatarFallback className="bg-primary text-primary-foreground text-sm">{initials ?? 'U'}</AvatarFallback>
+                </Avatar>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>
+                <div className="flex flex-col space-y-1">
+                  <p className="text-sm font-medium">{user?.displayName}</p>
+                  <p className="text-xs text-muted-foreground">{user?.email}</p>
+                </div>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => navigate('/profile')}>
+                <User className="mr-2 h-4 w-4" /> Profile
+              </DropdownMenuItem>
+              {user?.globalRole === 'SUPER_ADMIN' && (
+                <DropdownMenuItem onClick={() => navigate('/admin/settings')}>
+                  <Settings className="mr-2 h-4 w-4" /> Settings
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setAboutOpen(true)}>
+                <Info className="mr-2 h-4 w-4" /> About
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={logout} className="text-destructive">
+                <LogOut className="mr-2 h-4 w-4" /> Log out
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </header>
+
+      <Dialog open={aboutOpen} onOpenChange={setAboutOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader><DialogTitle>About Roomer</DialogTitle></DialogHeader>
+          <div className="space-y-3 py-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Version</span>
+              <span className="font-mono font-medium">{APP_VERSION}</span>
+            </div>
+            {APP_REPO_URL && (
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Source</span>
+                <a href={APP_REPO_URL} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-primary hover:underline">
+                  GitHub <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function BuildingsDropdown() {
+  const { buildingsData } = useNavConfig()
+  const navigate = useNavigate()
+  const [openBuilding, setOpenBuilding] = useState<string | null>(null)
+
+  const { data: buildingDetail } = useQuery({
+    queryKey: ['buildings', openBuilding],
+    queryFn: () => buildingsApi.get(openBuilding!),
+    select: (res) => res.data,
+    enabled: !!openBuilding,
+  })
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap">
+          <Building2 className="h-3.5 w-3.5" />
+          Buildings
+          <ChevronDown className="h-3 w-3" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-52">
+        {buildingsData.map((b) => (
+          <div key={b.id}>
+            <DropdownMenuItem
+              className="font-medium"
+              onSelect={(e) => {
+                e.preventDefault()
+                setOpenBuilding(openBuilding === b.id ? null : b.id)
+              }}
+            >
+              <Building2 className="mr-2 h-4 w-4" />
+              {b.name}
+              <ChevronDown className={cn('ml-auto h-3 w-3 transition-transform', openBuilding === b.id && 'rotate-180')} />
+            </DropdownMenuItem>
+            {openBuilding === b.id && buildingDetail?.floors?.map((floor) => (
+              <DropdownMenuItem
+                key={floor.id}
+                className="pl-8 text-muted-foreground"
+                onClick={() => navigate(`/floors/${floor.id}`)}
+              >
+                {floor.name}
+              </DropdownMenuItem>
+            ))}
+          </div>
+        ))}
+        {buildingsData.length === 0 && (
+          <DropdownMenuItem disabled>No buildings</DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/hooks/useNavConfig.ts
+++ b/apps/web/src/hooks/useNavConfig.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react'
+import { useAuthStore } from '@/stores/auth'
+import { useQuery } from '@tanstack/react-query'
+import { buildingsApi } from '@/lib/api'
+import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+export interface NavItem {
+  to: string
+  icon: LucideIcon
+  label: string
+}
+
+export interface NavSection {
+  id: string
+  label?: string
+  items: NavItem[]
+}
+
+export interface BuildingEntry {
+  id: string
+  name: string
+}
+
+export function useNavConfig() {
+  const user = useAuthStore((s) => s.user)
+  const isSuperAdmin = user?.globalRole === 'SUPER_ADMIN'
+
+  const managedFloors = useMemo(() => {
+    if (!user || isSuperAdmin) return []
+    const direct = (user.resourceRoles ?? [])
+      .filter((r) => r.role === 'FLOOR_MANAGER' && r.floorId && r.floor)
+      .map((r) => ({ id: r.floorId!, name: r.floor!.name }))
+    const viaGroup = (user.groupMemberships ?? []).flatMap((m) =>
+      (m.group.groupResourceRoles ?? [])
+        .filter((r) => r.role === 'FLOOR_MANAGER' && r.floorId && r.floor)
+        .map((r) => ({ id: r.floorId!, name: r.floor!.name })),
+    )
+    const byId = new Map<string, { id: string; name: string }>()
+    ;[...direct, ...viaGroup].forEach((f) => byId.set(f.id, f))
+    return [...byId.values()]
+  }, [user, isSuperAdmin])
+
+  const isFloorManager = managedFloors.length > 0
+
+  const { data: buildingsData } = useQuery({
+    queryKey: ['buildings'],
+    queryFn: () => buildingsApi.list(),
+    select: (res) => res.data,
+  })
+
+  const sections: NavSection[] = useMemo(() => {
+    const result: NavSection[] = [
+      {
+        id: 'personal',
+        items: [
+          { to: '/bookings', icon: Calendar, label: 'My Bookings' },
+          { to: '/queue', icon: Clock, label: 'My Queue' },
+          { to: '/assets', icon: Package, label: 'My Assets' },
+        ],
+      },
+    ]
+
+    if (isSuperAdmin) {
+      result.push({
+        id: 'admin',
+        label: 'Admin',
+        items: [
+          { to: '/admin/buildings', icon: Building2, label: 'Buildings' },
+          { to: '/admin/users', icon: Users, label: 'Users' },
+          { to: '/admin/assets', icon: Package, label: 'Assets' },
+          { to: '/admin/leases', icon: FileText, label: 'Leases' },
+          { to: '/admin/groups', icon: Shield, label: 'Access Groups' },
+          { to: '/admin/reports', icon: BarChart3, label: 'Reports' },
+          { to: '/admin/settings', icon: Settings, label: 'Settings' },
+        ],
+      })
+    } else if (isFloorManager) {
+      result.push({
+        id: 'manager',
+        label: 'Floor Manager',
+        items: [
+          { to: '/admin/assets', icon: Package, label: 'Assets' },
+          ...managedFloors.map((f) => ({ to: `/admin/floors/${f.id}`, icon: Layers, label: f.name })),
+        ],
+      })
+    }
+
+    return result
+  }, [isSuperAdmin, isFloorManager, managedFloors])
+
+  return { sections, buildingsData: buildingsData ?? [], isSuperAdmin, isFloorManager, managedFloors }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -432,6 +432,7 @@ export interface Branding {
   logoPath?: string
   faviconPath?: string
   borderRadius?: 'sharp' | 'medium' | 'large'
+  navStyle?: 'sidebar' | 'topbar' | 'floating' | 'rail'
   headerBanner?: BrandingBanner
   footerBanner?: BrandingBanner
 }

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -1492,6 +1492,7 @@ function BrandingCard() {
   const [primaryColor, setPrimaryColor] = useState('#6366f1')
   const [primaryColorDark, setPrimaryColorDark] = useState('#818cf8')
   const [borderRadius, setBorderRadius] = useState<Branding['borderRadius']>('medium')
+  const [navStyle, setNavStyle] = useState<Branding['navStyle']>('sidebar')
   const [headerBanner, setHeaderBanner] = useState<BrandingBanner>({
     enabled: false, text: '', bgColor: '#f59e0b', textColor: '#ffffff',
   })
@@ -1507,6 +1508,7 @@ function BrandingCard() {
     setPrimaryColor(brandingData.primaryColor ?? '#6366f1')
     setPrimaryColorDark(brandingData.primaryColorDark ?? '#818cf8')
     setBorderRadius(brandingData.borderRadius ?? 'medium')
+    setNavStyle(brandingData.navStyle ?? 'sidebar')
     if (brandingData.headerBanner) setHeaderBanner(brandingData.headerBanner)
     if (brandingData.footerBanner) setFooterBanner(brandingData.footerBanner)
   }, [brandingData])
@@ -1520,6 +1522,7 @@ function BrandingCard() {
         primaryColor,
         primaryColorDark,
         borderRadius,
+        navStyle,
         headerBanner,
         footerBanner,
       }),
@@ -1647,6 +1650,98 @@ function BrandingCard() {
                   style={{ borderRadius: opt.preview }}
                 />
                 {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Navigation Style */}
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-semibold">Navigation Style</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Choose how navigation is presented to all users</p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {([
+              {
+                value: 'sidebar' as const,
+                label: 'Enhanced Sidebar',
+                description: 'Collapsible & pinnable side panel',
+                preview: (
+                  <div className="flex h-10 w-full overflow-hidden rounded border border-current/20">
+                    <div className="w-5 border-r border-current/20 bg-current/10 flex flex-col gap-0.5 p-0.5">
+                      {[...Array(4)].map((_, i) => <div key={i} className="h-1 rounded-sm bg-current/40" />)}
+                    </div>
+                    <div className="flex-1 bg-current/5 p-1 space-y-0.5">
+                      {[...Array(3)].map((_, i) => <div key={i} className="h-1.5 rounded bg-current/20" />)}
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                value: 'topbar' as const,
+                label: 'Top Navigation',
+                description: 'Horizontal bar across the top',
+                preview: (
+                  <div className="flex h-10 w-full flex-col overflow-hidden rounded border border-current/20">
+                    <div className="flex h-4 items-center gap-1 border-b border-current/20 bg-current/10 px-1">
+                      {[...Array(4)].map((_, i) => <div key={i} className="h-1 w-4 rounded-sm bg-current/40" />)}
+                    </div>
+                    <div className="flex-1 bg-current/5 p-1 space-y-0.5">
+                      {[...Array(2)].map((_, i) => <div key={i} className="h-1.5 rounded bg-current/20" />)}
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                value: 'floating' as const,
+                label: 'Floating Island',
+                description: 'Glass-morphism pill floating at the bottom',
+                preview: (
+                  <div className="relative flex h-10 w-full overflow-hidden rounded border border-current/20 bg-current/5">
+                    <div className="absolute bottom-1 left-1/2 -translate-x-1/2 flex gap-1 rounded-lg border border-current/30 bg-current/15 px-2 py-0.5 backdrop-blur-sm">
+                      {[...Array(4)].map((_, i) => <div key={i} className="h-2 w-2 rounded-sm bg-current/50" />)}
+                    </div>
+                    <div className="p-1 space-y-0.5 w-full">
+                      {[...Array(2)].map((_, i) => <div key={i} className="h-1.5 rounded bg-current/20" />)}
+                    </div>
+                  </div>
+                ),
+              },
+              {
+                value: 'rail' as const,
+                label: 'Icon Rail',
+                description: 'Narrow icon strip with slide-out flyout',
+                preview: (
+                  <div className="flex h-10 w-full overflow-hidden rounded border border-current/20">
+                    <div className="w-3 border-r border-current/20 bg-current/10 flex flex-col items-center gap-0.5 py-0.5">
+                      {[...Array(4)].map((_, i) => <div key={i} className="h-1.5 w-1.5 rounded-sm bg-current/40" />)}
+                    </div>
+                    <div className="flex-1 bg-current/5 p-1 space-y-0.5">
+                      {[...Array(3)].map((_, i) => <div key={i} className="h-1.5 rounded bg-current/20" />)}
+                    </div>
+                  </div>
+                ),
+              },
+            ] as const).map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setNavStyle(opt.value)}
+                className={cn(
+                  'flex flex-col gap-2 rounded-lg border p-3 text-left text-xs transition-colors',
+                  navStyle === opt.value
+                    ? 'border-primary bg-primary/5 text-primary'
+                    : 'border-input text-muted-foreground hover:border-muted-foreground',
+                )}
+              >
+                {opt.preview}
+                <div>
+                  <p className="font-medium">{opt.label}</p>
+                  <p className="text-[11px] opacity-70 mt-0.5">{opt.description}</p>
+                </div>
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary

- Adds four admin-selectable navigation layouts (sidebar, topbar, floating, rail) stored in branding settings
- Floating style features three independently draggable glass-morphism elements with a rotatable nav island
- All nav styles share a `useNavConfig` hook for role-based sections and building data

## Changes

**API / Types**
- `settings.ts` — extends branding Zod schema with `navStyle` enum
- `api.ts` — mirrors `navStyle` on the frontend `Branding` interface

**Nav components** (`src/components/layout/navStyles/`)
- `SidebarNav` — collapsible and pinnable; collapses to 56px icon-only rail with tooltips; hover-to-expand when unpinned
- `TopNav` — full horizontal bar with dropdown flyouts for buildings, admin and manager sections
- `RailNav` — 48px icon rail with 220px slide-out flyout panel; closes on outside click and route change
- `FloatingNav` — three independently draggable elements (fixed logo mark, utility pill, nav island); nav island rotates in 5° increments via scroll-while-drag; inner items counter-rotate to stay upright; panels position via `getBoundingClientRect` so they sit flush at any rotation angle; panel direction adapts (above/below/left/right) based on rotation and screen position; all positions and rotation persist to localStorage

**Layout**
- `Layout.tsx` — switches on `branding.navStyle`; floating mode adds `pt-10` to `<main>` so page content clears the logo mark

**Settings UI**
- `SettingsAdminPage.tsx` — visual card picker in the Branding section with inline previews for each style