### PR TITLE
feat(notifications): booking reminders (#77)

### DIFF
--- a/apps/api/prisma/migrations/20260501000000_add_booking_reminders/migration.sql
+++ b/apps/api/prisma/migrations/20260501000000_add_booking_reminders/migration.sql
@@ -1,0 +1,8 @@
+-- Add booking reminder hours to Organisation (default 24 hours)
+ALTER TABLE "Organisation" ADD COLUMN "bookingReminderHours" INTEGER NOT NULL DEFAULT 24;
+
+-- Add reminderSentAt to Booking for deduplication
+ALTER TABLE "Booking" ADD COLUMN "reminderSentAt" TIMESTAMP(3);
+
+-- Add notificationPreferences to User (JSON, default empty object)
+ALTER TABLE "User" ADD COLUMN "notificationPreferences" JSONB NOT NULL DEFAULT '{}';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Organisation {
   dateFormat                  String      @default("dd/MM/yyyy")
   emailTemplates              Json        @default("{}")
   branding                    Json        @default("{}")
+  bookingReminderHours        Int         @default(24)
   createdAt                   DateTime    @default(now())
   updatedAt                   DateTime    @updatedAt
   buildings                   Building[]
@@ -380,16 +381,17 @@ model AssetAssignment {
 }
 
 model User {
-  id            String        @id @default(cuid())
-  email         String        @unique
-  displayName   String
-  passwordHash  String?
-  provider      AuthProvider  @default(LOCAL)
-  externalId    String?
-  accountStatus AccountStatus @default(ACTIVE)
-  globalRole    GlobalRole    @default(USER)
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
+  id                      String        @id @default(cuid())
+  email                   String        @unique
+  displayName             String
+  passwordHash            String?
+  provider                AuthProvider  @default(LOCAL)
+  externalId              String?
+  accountStatus           AccountStatus @default(ACTIVE)
+  globalRole              GlobalRole    @default(USER)
+  notificationPreferences Json          @default("{}")
+  createdAt               DateTime      @default(now())
+  updatedAt               DateTime      @updatedAt
 
   resourceRoles        UserResourceRole[]
   bookings             Booking[]
@@ -488,17 +490,18 @@ model GroupResourceRole {
 }
 
 model Booking {
-  id        String        @id @default(cuid())
-  userId    String
-  assetId   String
-  startsAt  DateTime
-  endsAt    DateTime
-  status    BookingStatus @default(CONFIRMED)
-  notes     String?
-  createdAt DateTime      @default(now())
-  updatedAt DateTime      @updatedAt
-  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  asset     Asset         @relation(fields: [assetId], references: [id], onDelete: Cascade)
+  id               String        @id @default(cuid())
+  userId           String
+  assetId          String
+  startsAt         DateTime
+  endsAt           DateTime
+  status           BookingStatus @default(CONFIRMED)
+  notes            String?
+  reminderSentAt   DateTime?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+  user             User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  asset            Asset         @relation(fields: [assetId], references: [id], onDelete: Cascade)
 
   @@index([assetId, startsAt, endsAt])
   @@index([userId, startsAt])

--- a/apps/api/src/lib/mailer.ts
+++ b/apps/api/src/lib/mailer.ts
@@ -383,6 +383,35 @@ export function renderQueueExpired(
 
 // ─── WELCOME ──────────────────────────────────────────────────────────────────
 
+export function renderBookingReminder(
+  booking: Pick<Booking, 'id' | 'startsAt' | 'endsAt'>,
+  user: Pick<User, 'displayName' | 'email'>,
+  asset: Pick<Asset, 'name'> & { zoneName?: string; floorName?: string },
+): { subject: string; html: string; text: string } {
+  const subject = `Reminder — ${escapeHtml(asset.name)} booking coming up`
+  const safeUser = escapeHtml(user.displayName)
+  const safeAsset = escapeHtml(asset.name)
+  const safeZone = asset.zoneName ? escapeHtml(asset.zoneName) : ''
+  const safeFloor = asset.floorName ? escapeHtml(asset.floorName) : ''
+  const html = baseHtml(
+    subject,
+    `<h1>Upcoming booking reminder</h1>
+     <p>Hi ${safeUser}, your booking is coming up soon.</p>
+     <div class="detail">
+       <dl>
+         <dt>Asset</dt><dd>${safeAsset}${safeZone ? ` — ${safeZone}` : ''}${safeFloor ? `, ${safeFloor}` : ''}</dd>
+         <dt>Starts</dt><dd>${formatDate(booking.startsAt)}</dd>
+         <dt>Ends</dt><dd>${formatDate(booking.endsAt)}</dd>
+       </dl>
+     </div>
+     <a href="${env.APP_URL}/bookings/${booking.id}" class="btn">View Booking</a>`,
+  )
+  const text = `Hi ${user.displayName},\n\nReminder: your booking for ${asset.name} starts at ${formatDate(booking.startsAt)}.\n\nView: ${env.APP_URL}/bookings/${booking.id}`
+  return { subject, html, text }
+}
+
+// ─── WELCOME ──────────────────────────────────────────────────────────────────
+
 export function renderWelcome(
   user: Pick<User, 'displayName' | 'email'>,
 ): { subject: string; html: string; text: string } {

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -1,7 +1,7 @@
 import { PgBoss, type Job } from 'pg-boss'
 import { env } from '../env'
 import { prisma } from './prisma'
-import { sendEmail, renderBookingConfirmed, renderBookingCancelled, renderQueueJoined, renderQueuePromoted, renderQueueExpired, renderWelcome, renderFloorAvailable, interpolateTemplate, stripHtmlToText, formatDate } from './mailer'
+import { sendEmail, renderBookingConfirmed, renderBookingCancelled, renderBookingReminder, renderQueueJoined, renderQueuePromoted, renderQueueExpired, renderWelcome, renderFloorAvailable, interpolateTemplate, stripHtmlToText, formatDate } from './mailer'
 import { randomUUID } from 'crypto'
 import { pruneExpiredBlocklistEntries } from './token-blocklist'
 import { NotificationType } from '@roomer/shared'
@@ -114,6 +114,29 @@ async function processSendNotification(
         bookingsUrl: `${env.APP_URL}/bookings`, appUrl: env.APP_URL,
       }
     }
+  } else if (type === NotificationType.BOOKING_REMINDER && bookingId) {
+    const booking = await prisma.booking.findUnique({
+      where: { id: bookingId },
+      include: { asset: { include: { primaryZone: { select: { name: true } }, floor: { select: { name: true } } } } },
+    })
+    if (booking) {
+      title = `Reminder — ${booking.asset.name} booking coming up`
+      body = `Your booking starts at ${formatDate(booking.startsAt)}.`
+      emailPayload = renderBookingReminder(booking, user, {
+        name: booking.asset.name,
+        zoneName: booking.asset.primaryZone?.name ?? '',
+        floorName: booking.asset.floor?.name ?? '',
+      })
+      templateVars = {
+        userName: user.displayName, userEmail: user.email,
+        assetName: booking.asset.name,
+        zoneName: booking.asset.primaryZone?.name ?? '',
+        floorName: booking.asset.floor?.name ?? '',
+        startsAt: formatDate(booking.startsAt), endsAt: formatDate(booking.endsAt),
+        bookingUrl: `${env.APP_URL}/bookings/${booking.id}`,
+        appUrl: env.APP_URL,
+      }
+    }
   } else if (type === NotificationType.QUEUE_JOINED && queueEntryId) {
     const entry = await prisma.queueEntry.findUnique({
       where: { id: queueEntryId },
@@ -210,22 +233,31 @@ async function processSendNotification(
     return
   }
 
-  // Persist in-app notification
-  await prisma.notification.create({
-    data: {
-      userId,
-      type,
-      title,
-      body,
-      metadata: {
-        bookingId: bookingId ?? null,
-        queueEntryId: queueEntryId ?? null,
-      },
-    },
-  })
+  // Respect per-user notification preferences. Missing key = both channels enabled.
+  type NotifPref = { email?: boolean; inApp?: boolean }
+  const prefs = (user as unknown as { notificationPreferences: Record<string, NotifPref> }).notificationPreferences ?? {}
+  const pref: NotifPref = prefs[type] ?? {}
+  const sendInApp = pref.inApp !== false
+  const sendEmailNotif = pref.email !== false
 
-  // Send email if we have a template
-  if (emailPayload) {
+  // Persist in-app notification (if not opted out)
+  if (sendInApp) {
+    await prisma.notification.create({
+      data: {
+        userId,
+        type,
+        title,
+        body,
+        metadata: {
+          bookingId: bookingId ?? null,
+          queueEntryId: queueEntryId ?? null,
+        },
+      },
+    })
+  }
+
+  // Send email if we have a template and user hasn't opted out
+  if (sendEmailNotif && emailPayload) {
     try {
       await sendEmail({ to: user.email, ...emailPayload })
     } catch (err) {
@@ -346,6 +378,48 @@ async function handleExpireClaimDeadlines(): Promise<void> {
   process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Processed expired claim deadlines', count: expiredPromoted.length }) + '\n')
 }
 
+// ─── Worker: send-booking-reminders (cron every 15 min) ──────────────────────
+
+async function handleSendBookingReminders(): Promise<void> {
+  const org = await prisma.organisation.findFirst({ select: { bookingReminderHours: true } })
+  const reminderHours = org?.bookingReminderHours ?? 24
+  const now = new Date()
+  const windowEnd = new Date(now.getTime() + reminderHours * 60 * 60 * 1000)
+
+  // Find confirmed bookings starting within the reminder window that haven't been reminded yet.
+  // We claim them immediately (set reminderSentAt) before enqueuing to prevent double-sends
+  // across overlapping cron invocations.
+  const bookings = await prisma.booking.findMany({
+    where: {
+      status: 'CONFIRMED',
+      startsAt: { gt: now, lte: windowEnd },
+      reminderSentAt: null,
+    },
+    select: { id: true, userId: true },
+  })
+
+  if (bookings.length === 0) return
+
+  await prisma.booking.updateMany({
+    where: { id: { in: bookings.map((b) => b.id) }, reminderSentAt: null },
+    data: { reminderSentAt: now },
+  })
+
+  const b = getBoss()
+  await b.insert(
+    'send-notification',
+    bookings.map((booking) => ({
+      data: {
+        type: NotificationType.BOOKING_REMINDER,
+        userId: booking.userId,
+        bookingId: booking.id,
+      } satisfies NotificationJobData,
+    })),
+  )
+
+  process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Enqueued booking reminders', count: bookings.length }) + '\n')
+}
+
 // ─── Start queue ──────────────────────────────────────────────────────────────
 
 export async function startQueue(): Promise<void> {
@@ -358,6 +432,7 @@ export async function startQueue(): Promise<void> {
   await b.createQueue('expire-claim-deadlines')
   await b.createQueue('prune-revoked-tokens')
   await b.createQueue('auto-complete-bookings')
+  await b.createQueue('send-booking-reminders')
 
   await b.work<NotificationJobData>('send-notification', handleSendNotification)
 
@@ -381,6 +456,11 @@ export async function startQueue(): Promise<void> {
     await pruneExpiredBlocklistEntries()
   })
   await b.schedule('prune-revoked-tokens', '*/30 * * * *', {})
+
+  await b.work('send-booking-reminders', async () => {
+    await handleSendBookingReminders()
+  })
+  await b.schedule('send-booking-reminders', '*/15 * * * *', {})
 
   process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] pg-boss started and workers registered' }) + '\n')
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -179,6 +179,7 @@ export interface User {
   externalId: string | null
   accountStatus: AccountStatus
   globalRole: GlobalRole
+  notificationPreferences: Record<string, { email?: boolean; inApp?: boolean }>
   createdAt: Date
   updatedAt: Date
 }
@@ -201,6 +202,7 @@ export interface Booking {
   endsAt: Date
   status: BookingStatus
   notes: string | null
+  reminderSentAt: Date | null
   createdAt: Date
   updatedAt: Date
 }


### PR DESCRIPTION
Closes #77

## Summary

- `Organisation.bookingReminderHours` (default: 24) — configurable reminder lead time per org
- `Booking.reminderSentAt` — deduplication field, set optimistically before enqueuing to prevent double-sends on overlapping cron ticks
- `User.notificationPreferences` JSON — per-type, per-channel opt-out `{ BOOKING_REMINDER: { email: false, inApp: true } }`. All channels default on; the preference check applies to every notification type
- New pg-boss cron `send-booking-reminders` (every 15 min) — scans for CONFIRMED bookings starting within the reminder window with no `reminderSentAt`
- `BOOKING_REMINDER` handler added to `processSendNotification` with email template
- Migration: `20260501000000_add_booking_reminders`