### PR TITLE
feat: building admin role (#73)

### DIFF
--- a/apps/api/src/middleware/requireRole.ts
+++ b/apps/api/src/middleware/requireRole.ts
@@ -156,6 +156,29 @@ export async function getManagedFloorIds(userId: string): Promise<string[]> {
   return [...new Set(ids)]
 }
 
+/**
+ * Middleware: passes for SUPER_ADMIN, or for users who hold BUILDING_ADMIN access
+ * on the building identified by `buildingIdParam` in request.params.
+ * Use `buildingIdParam = 'buildingId'` when the param isn't named `id`.
+ */
+export function requireBuildingAdmin(buildingIdParam = 'id') {
+  return async function (request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if (!request.user) {
+      return reply.status(401).send({ error: { message: 'Authentication required', code: 'UNAUTHENTICATED' } })
+    }
+    if (request.user.globalRole === GlobalRole.SUPER_ADMIN) return
+
+    const buildingId = (request.params as Record<string, string>)[buildingIdParam]
+    if (!buildingId) {
+      return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+    }
+    const ok = await isBuildingManagerForBuilding(request.user.id, buildingId)
+    if (!ok) {
+      return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+    }
+  }
+}
+
 // Middleware for asset endpoints: resolves asset → floorId directly, then checks floor-level role.
 // Also passes for SUPER_ADMIN.
 export function requireFloorRoleForAsset(minimumRole: ResourceRoleType) {

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma'
 import { GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
-import { requireGlobalRole } from '../middleware/requireRole'
+import { requireGlobalRole, getManagedBuildingIds } from '../middleware/requireRole'
 import { z } from 'zod'
 
 const analyticsQuerySchema = z.object({
@@ -37,16 +37,34 @@ function countWorkingDays(start: Date, end: Date): number {
 export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Analytics'], ...route.schema } })
 
-  // GET /utilisation — desk utilisation by floor/zone for a date range
+  // GET /utilisation — desk utilisation by floor/zone for a date range (SUPER_ADMIN or building admin)
   fastify.get(
     '/utilisation',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) {
         return reply.status(400).send({
           error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR' },
         })
+      }
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.buildingId && !managedBuildingIds.includes(result.data.buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.floorId) {
+          const floor = await prisma.floor.findUnique({ where: { id: result.data.floorId }, select: { buildingId: true } })
+          if (!floor || !managedBuildingIds.includes(floor.buildingId)) {
+            return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+          }
+        }
       }
 
       const defaults = defaultDateRange()
@@ -57,7 +75,11 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       // Build floor/building filters
       const floorWhere: Record<string, unknown> = {}
       if (result.data.floorId) floorWhere.id = result.data.floorId
-      if (result.data.buildingId) floorWhere.buildingId = result.data.buildingId
+      if (result.data.buildingId) {
+        floorWhere.buildingId = result.data.buildingId
+      } else if (!isSuperAdmin) {
+        floorWhere.buildingId = { in: managedBuildingIds }
+      }
 
       const floors = await prisma.floor.findMany({
         where: Object.keys(floorWhere).length > 0 ? floorWhere : undefined,
@@ -116,16 +138,34 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /bookings — booking counts by day for a date range
+  // GET /bookings — booking counts by day for a date range (SUPER_ADMIN or building admin)
   fastify.get(
     '/bookings',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) {
         return reply.status(400).send({
           error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR' },
         })
+      }
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.buildingId && !managedBuildingIds.includes(result.data.buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.floorId) {
+          const floor = await prisma.floor.findUnique({ where: { id: result.data.floorId }, select: { buildingId: true } })
+          if (!floor || !managedBuildingIds.includes(floor.buildingId)) {
+            return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+          }
+        }
       }
 
       const defaults = defaultDateRange()
@@ -158,6 +198,19 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
             AND b."startsAt" <= ${endDate}
             AND b.status = 'CONFIRMED'
             AND f."buildingId" = ${result.data.buildingId}
+          GROUP BY DATE(b."startsAt")
+          ORDER BY DATE(b."startsAt") ASC
+        `
+      } else if (!isSuperAdmin) {
+        rows = await prisma.$queryRaw<BookingCountRow[]>`
+          SELECT DATE(b."startsAt") AS date, COUNT(*)::bigint AS count
+          FROM "Booking" b
+          JOIN "Asset" a ON a.id = b."assetId"
+          JOIN "Floor" f ON f.id = a."floorId"
+          WHERE b."startsAt" >= ${startDate}
+            AND b."startsAt" <= ${endDate}
+            AND b.status = 'CONFIRMED'
+            AND f."buildingId" = ANY(${managedBuildingIds})
           GROUP BY DATE(b."startsAt")
           ORDER BY DATE(b."startsAt") ASC
         `
@@ -306,13 +359,25 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /floor-utilisation — floor-level aggregated utilisation
+  // GET /floor-utilisation — floor-level aggregated utilisation (SUPER_ADMIN or building admin)
   fastify.get(
     '/floor-utilisation',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) return reply.status(400).send({ error: { message: 'Invalid query', code: 'VALIDATION_ERROR' } })
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.buildingId && !managedBuildingIds.includes(result.data.buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
 
       const defaults = defaultDateRange()
       const startDate = result.data.startDate ? new Date(result.data.startDate + 'T00:00:00.000Z') : defaults.startDate
@@ -328,7 +393,11 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       if (workingDays === 0) workingDays = 1
 
       const floorWhere: Record<string, unknown> = {}
-      if (result.data.buildingId) floorWhere.buildingId = result.data.buildingId
+      if (result.data.buildingId) {
+        floorWhere.buildingId = result.data.buildingId
+      } else if (!isSuperAdmin) {
+        floorWhere.buildingId = { in: managedBuildingIds }
+      }
 
       const floors = await prisma.floor.findMany({
         where: Object.keys(floorWhere).length > 0 ? floorWhere : undefined,
@@ -377,16 +446,34 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /top-users — top users by booking count
+  // GET /top-users — top users by booking count (SUPER_ADMIN or building admin)
   fastify.get(
     '/top-users',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) {
         return reply.status(400).send({
           error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR' },
         })
+      }
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.buildingId && !managedBuildingIds.includes(result.data.buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.floorId) {
+          const floor = await prisma.floor.findUnique({ where: { id: result.data.floorId }, select: { buildingId: true } })
+          if (!floor || !managedBuildingIds.includes(floor.buildingId)) {
+            return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+          }
+        }
       }
 
       const defaults = defaultDateRange()
@@ -422,6 +509,21 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
             AND b."startsAt" <= ${endDate}
             AND b.status = 'CONFIRMED'
             AND f."buildingId" = ${result.data.buildingId}
+          GROUP BY b."userId", u."displayName", u.email
+          ORDER BY count DESC
+          LIMIT 20
+        `
+      } else if (!isSuperAdmin) {
+        rows = await prisma.$queryRaw<TopUserRow[]>`
+          SELECT b."userId", u."displayName", u.email, COUNT(*)::bigint AS count
+          FROM "Booking" b
+          JOIN "User" u ON u.id = b."userId"
+          JOIN "Asset" a ON a.id = b."assetId"
+          JOIN "Floor" f ON f.id = a."floorId"
+          WHERE b."startsAt" >= ${startDate}
+            AND b."startsAt" <= ${endDate}
+            AND b.status = 'CONFIRMED'
+            AND f."buildingId" = ANY(${managedBuildingIds})
           GROUP BY b."userId", u."displayName", u.email
           ORDER BY count DESC
           LIMIT 20

--- a/apps/api/src/routes/bookings.ts
+++ b/apps/api/src/routes/bookings.ts
@@ -3,7 +3,7 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '../lib/prisma'
 import { createBookingSchema, updateBookingSchema, GlobalRole, NotificationType } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
-import { requireGlobalRole } from '../middleware/requireRole'
+import { requireGlobalRole, isFloorManagerForFloor, getManagedBuildingIds } from '../middleware/requireRole'
 import { enqueueNotification, fanOutFloorAvailable, CLAIM_DEADLINE_MS } from '../lib/queue'
 import { randomUUID } from 'crypto'
 import { checkGroupAccess } from './groups'
@@ -84,16 +84,34 @@ async function checkZoneGroupOverlap(
 export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Bookings'], ...route.schema } })
 
-  // GET /bookings/report — admin paginated report (must be before /:id)
+  // GET /bookings/report — admin paginated report (SUPER_ADMIN or building admin, must be before /:id)
   fastify.get(
     '/report',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = reportQuerySchema.safeParse(request.query)
       if (!result.success) {
         return reply.status(400).send({
           error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR', details: result.error.flatten() },
         })
+      }
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.buildingId && !managedBuildingIds.includes(result.data.buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (result.data.floorId) {
+          const floor = await prisma.floor.findUnique({ where: { id: result.data.floorId }, select: { buildingId: true } })
+          if (!floor || !managedBuildingIds.includes(floor.buildingId)) {
+            return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+          }
+        }
       }
 
       const { from, to, userId, assetId, floorId, buildingId, status, page, limit } = result.data
@@ -112,6 +130,8 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
         where['asset'] = { floorId }
       } else if (buildingId) {
         where['asset'] = { floor: { buildingId } }
+      } else if (!isSuperAdmin) {
+        where['asset'] = { floor: { buildingId: { in: managedBuildingIds } } }
       }
 
       const [bookings, total] = await Promise.all([
@@ -411,21 +431,7 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
 
     if (!isSelf && !isAdmin) {
       const floorId = booking.asset?.floorId
-      const directRole = floorId
-        ? await prisma.userResourceRole.findFirst({
-            where: { userId: request.user.id, scopeType: 'FLOOR', floorId },
-          })
-        : null
-      const groupRole = (!directRole && floorId)
-        ? await prisma.groupResourceRole.findFirst({
-            where: {
-              scopeType: 'FLOOR',
-              floorId,
-              group: { members: { some: { userId: request.user.id } } },
-            },
-          })
-        : null
-      if (!directRole && !groupRole) {
+      if (!floorId || !(await isFloorManagerForFloor(request.user.id, floorId))) {
         return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
       }
     }

--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -4,7 +4,7 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma'
 import { createFloorSchema, updateFloorSchema, GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
-import { requireGlobalRole, isFloorManagerForFloor } from '../middleware/requireRole'
+import { requireGlobalRole, isFloorManagerForFloor, isBuildingManagerForBuilding } from '../middleware/requireRole'
 import { saveFloorPlan, resolveStoragePath, deleteFile } from '../lib/storage'
 import { canUserAccessBuilding } from './groups'
 import { env } from '../env'
@@ -49,12 +49,23 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(200).send({ data: floor })
   })
 
-  // GET /floors/:id/managers — list floor managers (SUPER_ADMIN only)
+  // GET /floors/:id/managers — list floor managers (SUPER_ADMIN or building admin)
   fastify.get(
     '/:id/managers',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const floor = await prisma.floor.findUnique({ where: { id }, select: { buildingId: true } })
+        if (!floor) {
+          return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+        }
+        const ok = await isBuildingManagerForBuilding(request.user.id, floor.buildingId)
+        if (!ok) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
 
       const roles = await prisma.userResourceRole.findMany({
         where: { scopeType: 'FLOOR', floorId: id, role: 'FLOOR_MANAGER' },
@@ -68,12 +79,23 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /floors/:id/group-managers — list group floor managers (SUPER_ADMIN only)
+  // GET /floors/:id/group-managers — list group floor managers (SUPER_ADMIN or building admin)
   fastify.get(
     '/:id/group-managers',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const floor = await prisma.floor.findUnique({ where: { id }, select: { buildingId: true } })
+        if (!floor) {
+          return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+        }
+        const ok = await isBuildingManagerForBuilding(request.user.id, floor.buildingId)
+        if (!ok) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
 
       const roles = await prisma.groupResourceRole.findMany({
         where: { scopeType: 'FLOOR', floorId: id, role: 'FLOOR_MANAGER' },
@@ -204,12 +226,24 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // DELETE /floors/:id
+  // DELETE /floors/:id (SUPER_ADMIN or building admin)
   fastify.delete(
     '/:id',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const floor = await prisma.floor.findUnique({ where: { id }, select: { buildingId: true } })
+        if (!floor) {
+          return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+        }
+        const ok = await isBuildingManagerForBuilding(request.user.id, floor.buildingId)
+        if (!ok) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
+
       try {
         await prisma.floor.delete({ where: { id } })
         return reply.status(200).send({ data: { ok: true } })

--- a/apps/api/src/routes/leases.ts
+++ b/apps/api/src/routes/leases.ts
@@ -3,9 +3,8 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma'
 import { GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth'
-import { requireGlobalRole } from '../middleware/requireRole'
+import { isBuildingManagerForBuilding, getManagedBuildingIds } from '../middleware/requireRole'
 import { resolveStoragePath, checkFileMagic } from '../lib/storage'
-import { env } from '../env'
 import path from 'path'
 import { z } from 'zod'
 
@@ -30,21 +29,39 @@ const updateLeaseSchema = z.object({
   notes: z.string().optional(),
 })
 
-const adminHandlers = [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)]
-
 export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Leases'], ...route.schema } })
 
-  // GET /leases?buildingId= — list leases
-  fastify.get('/', { preHandler: adminHandlers }, async (request, reply) => {
+  // GET /leases?buildingId= — list leases (SUPER_ADMIN or building admin, scoped to managed buildings)
+  fastify.get('/', { preHandler: [requireAuth] }, async (request, reply) => {
     const queryResult = z.object({ buildingId: z.string().cuid().optional() }).safeParse(request.query)
     if (!queryResult.success) {
       return reply.status(400).send({ error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR' } })
     }
     const { buildingId } = queryResult.data
 
+    const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+    let where: Record<string, unknown> | undefined
+
+    if (isSuperAdmin) {
+      where = buildingId ? { buildingId } : undefined
+    } else {
+      const managedIds = await getManagedBuildingIds(request.user.id)
+      if (managedIds.length === 0) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
+      if (buildingId) {
+        if (!managedIds.includes(buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        where = { buildingId }
+      } else {
+        where = { buildingId: { in: managedIds } }
+      }
+    }
+
     const leases = await prisma.buildingLease.findMany({
-      where: buildingId ? { buildingId } : undefined,
+      where,
       include: {
         building: { select: { id: true, name: true } },
         documents: { select: { id: true, filename: true, sizeBytes: true, mimeType: true, uploadedAt: true } },
@@ -55,13 +72,20 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(200).send({ data: leases })
   })
 
-  // POST /leases — create lease
-  fastify.post('/', { preHandler: adminHandlers }, async (request, reply) => {
+  // POST /leases — create lease (SUPER_ADMIN or building admin of the target building)
+  fastify.post('/', { preHandler: [requireAuth] }, async (request, reply) => {
     const result = createLeaseSchema.safeParse(request.body)
     if (!result.success) {
       return reply.status(400).send({
         error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() },
       })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const ok = await isBuildingManagerForBuilding(request.user.id, result.data.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
     }
 
     const building = await prisma.building.findUnique({ where: { id: result.data.buildingId } })
@@ -89,8 +113,8 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(201).send({ data: lease })
   })
 
-  // GET /leases/:id — get lease detail
-  fastify.get('/:id', { preHandler: adminHandlers }, async (request, reply) => {
+  // GET /leases/:id — get lease detail (SUPER_ADMIN or building admin)
+  fastify.get('/:id', { preHandler: [requireAuth] }, async (request, reply) => {
     const { id } = request.params as { id: string }
 
     const lease = await prisma.buildingLease.findUnique({
@@ -105,17 +129,36 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.status(404).send({ error: { message: 'Lease not found', code: 'NOT_FOUND' } })
     }
 
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const ok = await isBuildingManagerForBuilding(request.user.id, lease.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
+    }
+
     return reply.status(200).send({ data: lease })
   })
 
-  // PUT /leases/:id — update lease
-  fastify.put('/:id', { preHandler: adminHandlers }, async (request, reply) => {
+  // PUT /leases/:id — update lease (SUPER_ADMIN or building admin)
+  fastify.put('/:id', { preHandler: [requireAuth] }, async (request, reply) => {
     const { id } = request.params as { id: string }
     const result = updateLeaseSchema.safeParse(request.body)
     if (!result.success) {
       return reply.status(400).send({
         error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() },
       })
+    }
+
+    const existing = await prisma.buildingLease.findUnique({ where: { id }, select: { buildingId: true } })
+    if (!existing) {
+      return reply.status(404).send({ error: { message: 'Lease not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const ok = await isBuildingManagerForBuilding(request.user.id, existing.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
     }
 
     try {
@@ -139,8 +182,8 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     }
   })
 
-  // DELETE /leases/:id — delete lease (cascades documents)
-  fastify.delete('/:id', { preHandler: adminHandlers, config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (request, reply) => {
+  // DELETE /leases/:id — delete lease (SUPER_ADMIN or building admin)
+  fastify.delete('/:id', { preHandler: [requireAuth], config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { id } = request.params as { id: string }
 
     const lease = await prisma.buildingLease.findUnique({
@@ -150,6 +193,13 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
 
     if (!lease) {
       return reply.status(404).send({ error: { message: 'Lease not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const ok = await isBuildingManagerForBuilding(request.user.id, lease.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
     }
 
     // Delete stored document files
@@ -166,8 +216,8 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(200).send({ data: { ok: true } })
   })
 
-  // POST /leases/:id/documents — upload document
-  fastify.post('/:id/documents', { preHandler: adminHandlers, config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (request, reply) => {
+  // POST /leases/:id/documents — upload document (SUPER_ADMIN or building admin)
+  fastify.post('/:id/documents', { preHandler: [requireAuth], config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { id } = request.params as { id: string }
 
     if (!/^[\w-]{1,64}$/.test(id)) {
@@ -177,6 +227,13 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     const lease = await prisma.buildingLease.findUnique({ where: { id } })
     if (!lease) {
       return reply.status(404).send({ error: { message: 'Lease not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const ok = await isBuildingManagerForBuilding(request.user.id, lease.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
     }
 
     const data = await request.file()
@@ -231,13 +288,24 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(201).send({ data: doc })
   })
 
-  // GET /leases/:id/documents/:docId — download document
-  fastify.get('/:id/documents/:docId', { preHandler: adminHandlers, config: { rateLimit: { max: 60, timeWindow: '1 minute' } } }, async (request, reply) => {
+  // GET /leases/:id/documents/:docId — download document (SUPER_ADMIN or building admin)
+  fastify.get('/:id/documents/:docId', { preHandler: [requireAuth], config: { rateLimit: { max: 60, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { id, docId } = request.params as { id: string; docId: string }
 
     const doc = await prisma.leaseDocument.findUnique({ where: { id: docId } })
     if (!doc || doc.leaseId !== id) {
       return reply.status(404).send({ error: { message: 'Document not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const lease = await prisma.buildingLease.findUnique({ where: { id }, select: { buildingId: true } })
+      if (!lease) {
+        return reply.status(404).send({ error: { message: 'Lease not found', code: 'NOT_FOUND' } })
+      }
+      const ok = await isBuildingManagerForBuilding(request.user.id, lease.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
     }
 
     const docAbsPath = resolveStoragePath(doc.storagePath)
@@ -253,13 +321,24 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.send(stream)
   })
 
-  // DELETE /leases/:id/documents/:docId — delete document
-  fastify.delete('/:id/documents/:docId', { preHandler: adminHandlers, config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (request, reply) => {
+  // DELETE /leases/:id/documents/:docId — delete document (SUPER_ADMIN or building admin)
+  fastify.delete('/:id/documents/:docId', { preHandler: [requireAuth], config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { id, docId } = request.params as { id: string; docId: string }
 
     const doc = await prisma.leaseDocument.findUnique({ where: { id: docId } })
     if (!doc || doc.leaseId !== id) {
       return reply.status(404).send({ error: { message: 'Document not found', code: 'NOT_FOUND' } })
+    }
+
+    if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      const lease = await prisma.buildingLease.findUnique({ where: { id }, select: { buildingId: true } })
+      if (!lease) {
+        return reply.status(404).send({ error: { message: 'Lease not found', code: 'NOT_FOUND' } })
+      }
+      const ok = await isBuildingManagerForBuilding(request.user.id, lease.buildingId)
+      if (!ok) {
+        return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
     }
 
     const absPath = resolveStoragePath(doc.storagePath)

--- a/apps/web/src/hooks/useNavConfig.ts
+++ b/apps/web/src/hooks/useNavConfig.ts
@@ -41,7 +41,23 @@ export function useNavConfig() {
     return [...byId.values()]
   }, [user, isSuperAdmin])
 
+  const managedBuildings = useMemo(() => {
+    if (!user || isSuperAdmin) return []
+    const direct = (user.resourceRoles ?? [])
+      .filter((r) => r.role === 'BUILDING_ADMIN' && r.buildingId && r.building)
+      .map((r) => ({ id: r.buildingId!, name: r.building!.name }))
+    const viaGroup = (user.groupMemberships ?? []).flatMap((m) =>
+      (m.group.groupResourceRoles ?? [])
+        .filter((r) => r.role === 'BUILDING_ADMIN' && r.buildingId && r.building)
+        .map((r) => ({ id: r.buildingId!, name: r.building!.name })),
+    )
+    const byId = new Map<string, { id: string; name: string }>()
+    ;[...direct, ...viaGroup].forEach((b) => byId.set(b.id, b))
+    return [...byId.values()]
+  }, [user, isSuperAdmin])
+
   const isFloorManager = managedFloors.length > 0
+  const isBuildingAdmin = managedBuildings.length > 0
 
   const { data: buildingsData } = useQuery({
     queryKey: ['buildings'],
@@ -75,6 +91,17 @@ export function useNavConfig() {
           { to: '/admin/settings', icon: Settings, label: 'Settings' },
         ],
       })
+    } else if (isBuildingAdmin) {
+      result.push({
+        id: 'building-admin',
+        label: 'My Buildings',
+        items: [
+          ...managedBuildings.map((b) => ({ to: `/admin/buildings/${b.id}`, icon: Building2, label: b.name })),
+          { to: '/admin/assets', icon: Package, label: 'Assets' },
+          { to: '/admin/leases', icon: FileText, label: 'Leases' },
+          { to: '/admin/reports', icon: BarChart3, label: 'Reports' },
+        ],
+      })
     } else if (isFloorManager) {
       result.push({
         id: 'manager',
@@ -87,7 +114,7 @@ export function useNavConfig() {
     }
 
     return result
-  }, [isSuperAdmin, isFloorManager, managedFloors])
+  }, [isSuperAdmin, isBuildingAdmin, isFloorManager, managedBuildings, managedFloors])
 
-  return { sections, buildingsData: buildingsData ?? [], isSuperAdmin, isFloorManager, managedFloors }
+  return { sections, buildingsData: buildingsData ?? [], isSuperAdmin, isBuildingAdmin, isFloorManager, managedFloors, managedBuildings }
 }


### PR DESCRIPTION
## Summary

- Building admins can now manage everything within their assigned buildings (floors, zones, assets, leases, analytics, booking cancellations)
- SUPER_ADMIN retains full unrestricted access; building admin access is scoped to their managed buildings only
- Sidebar shows a \"My Buildings\" section for building admins, replacing the generic admin section

## API changes

**`requireRole.ts`** — Added `requireBuildingAdmin` middleware and exported `isBuildingManagerForBuilding` / `getManagedBuildingIds` helpers (already existed internally)

**`floors.ts`**
- `GET /:id/managers` and `GET /:id/group-managers` — now accessible to building admins for their buildings
- `DELETE /:id` — now accessible to building admins for their buildings (SUPER_ADMIN only for POST `/` — floor creation stays locked)

**`leases.ts`**
- All lease routes now accept building admins, scoped to their buildings
- `GET /` auto-scopes to managed buildings when no `buildingId` filter is provided
- Removed shared `adminHandlers` const; each route has inline auth

**`analytics.ts`**
- `/utilisation`, `/floor-utilisation`, `/bookings`, `/top-users` — open to building admins, auto-scoped to managed buildings
- `/summary`, `/status-breakdown`, `/peak-days` — remain SUPER_ADMIN only (org-wide stats)

**`bookings.ts`**
- `GET /report` — building admins can access, scoped to their managed buildings
- `DELETE /:id` — replaced manual role check with `isFloorManagerForFloor` which correctly inherits building admin access

## Frontend changes

**`useNavConfig.ts`**
- Detects `BUILDING_ADMIN` resource roles (direct and via group membership)
- Shows \"My Buildings\" nav section with per-building links, Assets, Leases, Reports

## Test plan

- [ ] Assign BUILDING_ADMIN role to a test user for a specific building
- [ ] Verify the user sees \"My Buildings\" in the sidebar with their building(s)
- [ ] Verify they can access floors, delete floors, view floor managers for their building
- [ ] Verify they can view/create/edit/delete leases for their building but not others
- [ ] Verify analytics routes return data scoped to their buildings
- [ ] Verify they can cancel bookings on floors within their building
- [ ] Verify SUPER_ADMIN still sees all data unscoped
- [ ] Verify a regular user with no roles gets 403 on all admin routes