### PR TITLE
feat: recurring bookings (#67)

### DIFF
--- a/apps/api/prisma/migrations/20260502100000_add_recurring_frequency/migration.sql
+++ b/apps/api/prisma/migrations/20260502100000_add_recurring_frequency/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "RecurringFrequency" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY');
+
+-- AlterTable: add frequency, make dayOfWeek nullable, backfill existing rows as WEEKLY
+ALTER TABLE "RecurringBookingRule"
+  ADD COLUMN "frequency" "RecurringFrequency" NOT NULL DEFAULT 'WEEKLY',
+  ALTER COLUMN "dayOfWeek" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -58,6 +58,17 @@ enum BookingStatus {
   COMPLETED
 }
 
+enum RecurringRuleStatus {
+  ACTIVE
+  CANCELLED
+}
+
+enum RecurringFrequency {
+  DAILY
+  WEEKLY
+  MONTHLY
+}
+
 enum QueueEntryStatus {
   WAITING
   PROMOTED
@@ -116,6 +127,7 @@ model Organisation {
   emailTemplates              Json        @default("{}")
   branding                    Json        @default("{}")
   bookingReminderHours        Int         @default(24)
+  maxRecurringBookingWeeks    Int         @default(12)
   createdAt                   DateTime    @default(now())
   updatedAt                   DateTime    @updatedAt
   buildings                   Building[]
@@ -322,8 +334,9 @@ model Asset {
   /// Temporary assignments (checked-out to a user with a return date).
   assignments     AssetAssignment[]
   /// Bookings made against this asset (only populated when isBookable=true).
-  bookings        Booking[]
-  queueEntries    QueueEntry[]
+  bookings              Booking[]
+  queueEntries          QueueEntry[]
+  recurringBookingRules RecurringBookingRule[]
 
   @@index([floorId])
   @@index([primaryZoneId])
@@ -402,8 +415,9 @@ model User {
   assetAllowList       AssetAllowList[]
   groupMemberships     UserGroupMember[]
   assetUserAssignments AssetUserAssignment[]
-  availabilityWindows  AssetAvailabilityWindow[] @relation("AvailabilityWindowOwner")
-  floorSubscriptions   FloorSubscription[]
+  availabilityWindows   AssetAvailabilityWindow[] @relation("AvailabilityWindowOwner")
+  floorSubscriptions    FloorSubscription[]
+  recurringBookingRules RecurringBookingRule[]
 
   @@index([email])
   @@index([provider, externalId])
@@ -490,22 +504,53 @@ model GroupResourceRole {
 }
 
 model Booking {
-  id               String        @id @default(cuid())
-  userId           String
-  assetId          String
-  startsAt         DateTime
-  endsAt           DateTime
-  status           BookingStatus @default(CONFIRMED)
-  notes            String?
-  reminderSentAt   DateTime?
-  createdAt        DateTime      @default(now())
-  updatedAt        DateTime      @updatedAt
-  user             User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  asset            Asset         @relation(fields: [assetId], references: [id], onDelete: Cascade)
+  id                String               @id @default(cuid())
+  userId            String
+  assetId           String
+  startsAt          DateTime
+  endsAt            DateTime
+  status            BookingStatus        @default(CONFIRMED)
+  notes             String?
+  reminderSentAt    DateTime?
+  recurringRuleId   String?
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
+  user              User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  asset             Asset                @relation(fields: [assetId], references: [id], onDelete: Cascade)
+  recurringRule     RecurringBookingRule? @relation(fields: [recurringRuleId], references: [id], onDelete: SetNull)
 
   @@index([assetId, startsAt, endsAt])
   @@index([userId, startsAt])
+  @@index([recurringRuleId])
   @@index([status])
+}
+
+/// A weekly recurring booking rule. All individual Booking rows linked to this
+/// rule are materialized immediately at creation time.
+model RecurringBookingRule {
+  id          String               @id @default(cuid())
+  userId      String
+  assetId     String
+  frequency   RecurringFrequency   @default(WEEKLY)
+  /// ISO day of week: 0=Sunday … 6=Saturday. Required only for WEEKLY frequency.
+  dayOfWeek   Int?
+  /// Wall-clock start time in HH:MM UTC
+  startTime   String
+  /// Wall-clock end time in HH:MM UTC
+  endTime     String
+  /// Date of first occurrence (stored as midnight UTC)
+  firstDate   DateTime             @db.Date
+  /// Date of last occurrence (stored as midnight UTC)
+  lastDate    DateTime             @db.Date
+  status      RecurringRuleStatus  @default(ACTIVE)
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+  user        User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  asset       Asset               @relation(fields: [assetId], references: [id], onDelete: Cascade)
+  bookings    Booking[]
+
+  @@index([userId])
+  @@index([assetId])
 }
 
 model QueueEntry {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -25,6 +25,7 @@ import { enterpriseAuthRoutes } from './routes/auth-enterprise'
 import { importRoutes } from './routes/import'
 import { scimRoutes } from './routes/scim'
 import { subscriptionRoutes } from './routes/subscriptions'
+import { recurringBookingRoutes } from './routes/recurring'
 import { getBoss } from './lib/queue'
 import { prisma } from './lib/prisma'
 import { register, httpRequestDuration, setupMetrics } from './lib/metrics'
@@ -113,6 +114,8 @@ export async function buildApp(): Promise<FastifyInstance> {
           { name: 'Leases', description: 'Building lease management (admin only)' },
           { name: 'Settings', description: 'System configuration — branding, SSO, email (admin only)' },
           { name: 'Import', description: 'Bulk data import (admin only)' },
+          { name: 'Subscriptions', description: 'Floor availability subscriptions and notifications' },
+          { name: 'Recurring Bookings', description: 'Weekly recurring booking rules and series management' },
         ],
         components: {
           securitySchemes: {
@@ -224,6 +227,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(settingsRoutes, { prefix: '/api/v1/settings' })
   await fastify.register(importRoutes, { prefix: '/api/v1/import' })
   await fastify.register(subscriptionRoutes, { prefix: '/api/v1/subscriptions' })
+  await fastify.register(recurringBookingRoutes, { prefix: '/api/v1/recurring-bookings' })
   await fastify.register(scimRoutes, { prefix: '/scim/v2' })
 
   // ─── Health checks ─────────────────────────────────────────────────────────

--- a/apps/api/src/routes/recurring.ts
+++ b/apps/api/src/routes/recurring.ts
@@ -1,0 +1,283 @@
+import type { FastifyInstance } from 'fastify'
+import { prisma } from '../lib/prisma'
+import { GlobalRole, NotificationType } from '@roomer/shared'
+import { requireAuth } from '../middleware/requireAuth'
+import { z } from 'zod'
+import { enqueueNotification } from '../lib/queue'
+
+const createRecurringSchema = z.object({
+  assetId: z.string().min(1),
+  frequency: z.enum(['DAILY', 'WEEKLY', 'MONTHLY']).default('WEEKLY'),
+  dayOfWeek: z.number().int().min(0).max(6).optional(),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/, 'startTime must be HH:MM'),
+  endTime: z.string().regex(/^\d{2}:\d{2}$/, 'endTime must be HH:MM'),
+  firstDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'firstDate must be YYYY-MM-DD'),
+  lastDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'lastDate must be YYYY-MM-DD'),
+}).refine(
+  (d) => d.frequency !== 'WEEKLY' || d.dayOfWeek !== undefined,
+  { message: 'dayOfWeek is required for weekly recurrence', path: ['dayOfWeek'] },
+)
+
+function parseTimeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number)
+  return h * 60 + m
+}
+
+function buildSlotDatetime(dateUtcMidnight: Date, timeHHMM: string): Date {
+  const [h, m] = timeHHMM.split(':').map(Number)
+  const dt = new Date(dateUtcMidnight)
+  dt.setUTCHours(h, m, 0, 0)
+  return dt
+}
+
+function getOccurrenceDates(
+  frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY',
+  dayOfWeek: number | undefined,
+  firstDate: string,
+  lastDate: string,
+): Date[] {
+  const start = new Date(firstDate + 'T00:00:00.000Z')
+  const end = new Date(lastDate + 'T00:00:00.000Z')
+  const dates: Date[] = []
+  const cursor = new Date(start)
+
+  if (frequency === 'DAILY') {
+    while (cursor <= end) {
+      dates.push(new Date(cursor))
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
+    }
+  } else if (frequency === 'WEEKLY') {
+    while (cursor.getUTCDay() !== dayOfWeek!) {
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
+    }
+    while (cursor <= end) {
+      dates.push(new Date(cursor))
+      cursor.setUTCDate(cursor.getUTCDate() + 7)
+    }
+  } else {
+    // MONTHLY — repeat on the same day-of-month; clamp to last day when month is shorter
+    const targetDay = start.getUTCDate()
+    while (cursor <= end) {
+      dates.push(new Date(cursor))
+      const nextMonth = (cursor.getUTCMonth() + 1) % 12
+      const nextYear = cursor.getUTCMonth() === 11 ? cursor.getUTCFullYear() + 1 : cursor.getUTCFullYear()
+      const daysInNextMonth = new Date(Date.UTC(nextYear, nextMonth + 1, 0)).getUTCDate()
+      cursor.setUTCFullYear(nextYear, nextMonth, Math.min(targetDay, daysInNextMonth))
+    }
+  }
+
+  return dates
+}
+
+export async function recurringBookingRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Recurring Bookings'], ...route.schema } })
+
+  // POST /recurring-bookings — create rule + materialise all bookings
+  fastify.post('/', { preHandler: [requireAuth] }, async (request, reply) => {
+    const result = createRecurringSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({
+        error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() },
+      })
+    }
+
+    const { assetId, frequency, dayOfWeek, startTime, endTime, firstDate, lastDate } = result.data
+
+    if (parseTimeToMinutes(startTime) >= parseTimeToMinutes(endTime)) {
+      return reply.status(400).send({ error: { message: 'startTime must be before endTime', code: 'VALIDATION_ERROR' } })
+    }
+
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+    const firstDateObj = new Date(firstDate + 'T00:00:00.000Z')
+    const lastDateObj = new Date(lastDate + 'T00:00:00.000Z')
+
+    if (firstDateObj < today) {
+      return reply.status(400).send({ error: { message: 'firstDate must be today or in the future', code: 'VALIDATION_ERROR' } })
+    }
+    if (lastDateObj < firstDateObj) {
+      return reply.status(400).send({ error: { message: 'lastDate must be on or after firstDate', code: 'VALIDATION_ERROR' } })
+    }
+
+    const org = await prisma.organisation.findFirst({
+      select: { maxRecurringBookingWeeks: true, maxAdvanceBookingDays: true },
+    })
+    const maxWeeks = org?.maxRecurringBookingWeeks ?? 12
+    const spanMs = lastDateObj.getTime() - firstDateObj.getTime()
+    const spanWeeks = spanMs / (7 * 24 * 60 * 60 * 1000)
+    if (spanWeeks > maxWeeks) {
+      return reply.status(400).send({
+        error: { message: `Recurring booking span cannot exceed ${maxWeeks} weeks`, code: 'MAX_RECURRENCE_EXCEEDED' },
+      })
+    }
+
+    const asset = await prisma.asset.findUnique({
+      where: { id: assetId },
+      include: {
+        allowList: { select: { userId: true } },
+        userAssignments: { select: { userId: true } },
+        floor: { select: { id: true, buildingId: true } },
+      },
+    })
+    if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+    if (!asset.isBookable) return reply.status(409).send({ error: { message: 'Asset is not bookable', code: 'ASSET_NOT_BOOKABLE' } })
+    if (asset.bookingStatus === 'DISABLED') return reply.status(409).send({ error: { message: 'Asset is disabled', code: 'ASSET_DISABLED' } })
+
+    if (asset.bookingStatus === 'RESTRICTED') {
+      const onList = asset.allowList.some((e) => e.userId === request.user.id)
+      const isAssigned = asset.userAssignments.some((ua) => ua.userId === request.user.id)
+      if (!onList && !isAssigned && request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        return reply.status(403).send({ error: { message: 'You are not permitted to book this asset', code: 'FORBIDDEN' } })
+      }
+    }
+
+    const occurrenceDates = getOccurrenceDates(frequency, dayOfWeek, firstDate, lastDate)
+    if (occurrenceDates.length === 0) {
+      return reply.status(400).send({ error: { message: 'No occurrences found for the given day and date range', code: 'NO_OCCURRENCES' } })
+    }
+
+    const slots = occurrenceDates.map((d) => ({
+      startsAt: buildSlotDatetime(d, startTime),
+      endsAt: buildSlotDatetime(d, endTime),
+    }))
+
+    try {
+      const rule = await prisma.$transaction(async (tx) => {
+        // Check all slots for conflicts atomically
+        for (const slot of slots) {
+          const conflict = await tx.booking.findFirst({
+            where: {
+              assetId,
+              status: 'CONFIRMED',
+              startsAt: { lt: slot.endsAt },
+              endsAt: { gt: slot.startsAt },
+            },
+            select: { id: true, startsAt: true },
+          })
+          if (conflict) {
+            throw Object.assign(new Error('CONFLICT'), {
+              code: 'BOOKING_CONFLICT',
+              conflictAt: conflict.startsAt.toISOString().split('T')[0],
+            })
+          }
+        }
+
+        const createdRule = await tx.recurringBookingRule.create({
+          data: {
+            userId: request.user.id,
+            assetId,
+            frequency,
+            dayOfWeek: dayOfWeek ?? null,
+            startTime,
+            endTime,
+            firstDate: firstDateObj,
+            lastDate: lastDateObj,
+            bookings: {
+              create: slots.map((s) => ({
+                userId: request.user.id,
+                assetId,
+                startsAt: s.startsAt,
+                endsAt: s.endsAt,
+                status: 'CONFIRMED',
+              })),
+            },
+          },
+          include: {
+            bookings: { select: { id: true, startsAt: true, endsAt: true } },
+            asset: { select: { id: true, name: true, floor: { select: { name: true, building: { select: { name: true } } } } } },
+          },
+        })
+
+        return createdRule
+      })
+
+      // Single confirmation notification for the first booking in the series
+      await enqueueNotification({
+        type: NotificationType.BOOKING_CONFIRMED,
+        userId: request.user.id,
+        bookingId: rule.bookings[0].id,
+      })
+
+      return reply.status(201).send({ data: rule })
+    } catch (err: unknown) {
+      const e = err as { code?: string; conflictAt?: string }
+      if (e.code === 'BOOKING_CONFLICT') {
+        return reply.status(409).send({
+          error: {
+            message: `Booking conflict on ${e.conflictAt} — the entire series was not created`,
+            code: 'BOOKING_CONFLICT',
+          },
+        })
+      }
+      throw err
+    }
+  })
+
+  // GET /recurring-bookings — list current user's rules
+  fastify.get('/', { preHandler: [requireAuth] }, async (request, reply) => {
+    const rules = await prisma.recurringBookingRule.findMany({
+      where: { userId: request.user.id },
+      include: {
+        asset: { select: { id: true, name: true, bookingLabel: true, floor: { select: { name: true, building: { select: { name: true } } } } } },
+        bookings: {
+          where: { status: 'CONFIRMED', startsAt: { gte: new Date() } },
+          select: { id: true, startsAt: true, endsAt: true },
+          orderBy: { startsAt: 'asc' },
+        },
+        _count: { select: { bookings: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+    return reply.status(200).send({ data: rules })
+  })
+
+  // GET /recurring-bookings/:id — get rule with all bookings
+  fastify.get('/:id', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const rule = await prisma.recurringBookingRule.findUnique({
+      where: { id },
+      include: {
+        asset: { select: { id: true, name: true, bookingLabel: true, floor: { select: { name: true, building: { select: { name: true } } } } } },
+        bookings: {
+          select: { id: true, startsAt: true, endsAt: true, status: true },
+          orderBy: { startsAt: 'asc' },
+        },
+      },
+    })
+    if (!rule) return reply.status(404).send({ error: { message: 'Rule not found', code: 'NOT_FOUND' } })
+    if (rule.userId !== request.user.id && request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+    }
+    return reply.status(200).send({ data: rule })
+  })
+
+  // DELETE /recurring-bookings/:id — cancel rule + all future bookings
+  fastify.delete('/:id', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const rule = await prisma.recurringBookingRule.findUnique({
+      where: { id },
+      select: { id: true, userId: true, status: true },
+    })
+    if (!rule) return reply.status(404).send({ error: { message: 'Rule not found', code: 'NOT_FOUND' } })
+    if (rule.userId !== request.user.id && request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+    }
+    if (rule.status === 'CANCELLED') {
+      return reply.status(409).send({ error: { message: 'Rule is already cancelled', code: 'ALREADY_CANCELLED' } })
+    }
+
+    const now = new Date()
+    await prisma.$transaction([
+      prisma.booking.updateMany({
+        where: { recurringRuleId: id, status: 'CONFIRMED', startsAt: { gt: now } },
+        data: { status: 'CANCELLED' },
+      }),
+      prisma.recurringBookingRule.update({
+        where: { id },
+        data: { status: 'CANCELLED' },
+      }),
+    ])
+
+    return reply.status(200).send({ data: { ok: true } })
+  })
+}

--- a/apps/web/src/components/floor-plan/DeskPanel.tsx
+++ b/apps/web/src/components/floor-plan/DeskPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { format, addHours, startOfDay, addDays } from 'date-fns'
 import { formatDateTime } from '@/lib/utils'
-import { MapPin, Clock, Users, CheckCircle, XCircle, AlertCircle, Shield, UserPlus, UserMinus, ChevronDown, ChevronUp, Pencil, X } from 'lucide-react'
+import { MapPin, Clock, Users, CheckCircle, XCircle, AlertCircle, Shield, UserPlus, UserMinus, ChevronDown, ChevronUp, Pencil, X, Repeat } from 'lucide-react'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -18,7 +18,7 @@ import { useCreateBooking, useJoinQueue, useLeaveQueue, useClaimDesk, useCancelB
 import { formatDateRange } from '@/lib/utils'
 import { getDateFormat } from '@/lib/dateFormat'
 import { useAuthStore } from '@/stores/auth'
-import { assetsApi, usersApi, settingsApi } from '@/lib/api'
+import { assetsApi, usersApi, settingsApi, recurringBookingsApi } from '@/lib/api'
 import type { AssetWithStatus } from '@/types'
 
 interface DeskPanelProps {
@@ -440,9 +440,14 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
   const [customEnd, setCustomEnd] = useState('17:00')
   const [endDate, setEndDate] = useState<Date>(date)
   const [queueExpiry, setQueueExpiry] = useState('')
+  const [isRecurring, setIsRecurring] = useState(false)
+  const [recurringFrequency, setRecurringFrequency] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY'>('WEEKLY')
+  const [recurringLastDate, setRecurringLastDate] = useState('')
 
   // Keep endDate in sync when the floor page navigates to a different day
   useEffect(() => { setEndDate(date) }, [date])
+  // Reset recurring state when a different asset is selected
+  useEffect(() => { setIsRecurring(false); setRecurringFrequency('WEEKLY'); setRecurringLastDate('') }, [desk?.id])
   const [showAdmin, setShowAdmin] = useState(false)
   const [editAssetOpen, setEditAssetOpen] = useState(false)
   const [addAllowListOpen, setAddAllowListOpen] = useState(false)
@@ -538,7 +543,37 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
     onError: () => toast.error('Failed to remove zone'),
   })
 
+  const getRecurringTimes = (): { startTime: string; endTime: string } => {
+    if (timePreset === 'full') return { startTime: '00:00', endTime: '23:59' }
+    if (timePreset === 'am') return { startTime: '08:00', endTime: '13:00' }
+    if (timePreset === 'pm') return { startTime: '13:00', endTime: '18:00' }
+    return { startTime: customStart, endTime: customEnd }
+  }
+
+  const createRecurring = useMutation({
+    mutationFn: () => {
+      const { startTime, endTime } = getRecurringTimes()
+      return recurringBookingsApi.create({
+        assetId: desk?.id ?? '',
+        frequency: recurringFrequency,
+        ...(recurringFrequency === 'WEEKLY' ? { dayOfWeek: date.getDay() } : {}),
+        startTime,
+        endTime,
+        firstDate: format(date, 'yyyy-MM-dd'),
+        lastDate: recurringLastDate,
+      })
+    },
+    onSuccess: () => {
+      toast.success('Recurring booking series created')
+      qc.invalidateQueries({ queryKey: ['recurring-bookings'] })
+      onBookingCreated()
+    },
+    onError: (err: Error) => toast.error(err.message),
+  })
+
   if (!desk) return null
+
+  const categoryName = desk.category?.name ?? 'Asset'
 
   const getBookingTimes = () => {
     const base = startOfDay(date)
@@ -743,24 +778,27 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
 
             {desk.bookingStatus === 'available' && (
               <div className="space-y-4">
-                <div>
-                  <Label className="text-sm font-medium">End date</Label>
-                  <Input
-                    type="date"
-                    value={format(endDate, 'yyyy-MM-dd')}
-                    min={format(date, 'yyyy-MM-dd')}
-                    max={maxEndDateStr}
-                    onChange={(e) => {
-                      if (e.target.value) setEndDate(new Date(e.target.value + 'T00:00:00'))
-                    }}
-                    className="mt-1.5"
-                  />
-                  {isMultiDay && (
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {Math.round((startOfDay(endDate).getTime() - startOfDay(date).getTime()) / 86400000) + 1} day booking
-                    </p>
-                  )}
-                </div>
+                {/* End date — hidden when recurring (recurring uses its own "Repeat until" date) */}
+                {!isRecurring && (
+                  <div>
+                    <Label className="text-sm font-medium">End date</Label>
+                    <Input
+                      type="date"
+                      value={format(endDate, 'yyyy-MM-dd')}
+                      min={format(date, 'yyyy-MM-dd')}
+                      max={maxEndDateStr}
+                      onChange={(e) => {
+                        if (e.target.value) setEndDate(new Date(e.target.value + 'T00:00:00'))
+                      }}
+                      className="mt-1.5"
+                    />
+                    {isMultiDay && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {Math.round((startOfDay(endDate).getTime() - startOfDay(date).getTime()) / 86400000) + 1} day booking
+                      </p>
+                    )}
+                  </div>
+                )}
 
                 <div>
                   <Label className="text-sm font-medium">Time</Label>
@@ -773,8 +811,8 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="full">Full Day (all day)</SelectItem>
-                      <SelectItem value="am" disabled={isMultiDay}>Morning (08:00 – 13:00)</SelectItem>
-                      <SelectItem value="pm" disabled={isMultiDay}>Afternoon (13:00 – 18:00)</SelectItem>
+                      <SelectItem value="am" disabled={isMultiDay && !isRecurring}>Morning (08:00 – 13:00)</SelectItem>
+                      <SelectItem value="pm" disabled={isMultiDay && !isRecurring}>Afternoon (13:00 – 18:00)</SelectItem>
                       <SelectItem value="custom">Custom time</SelectItem>
                     </SelectContent>
                   </Select>
@@ -783,7 +821,7 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
                 {timePreset === 'custom' && (
                   <div className="grid grid-cols-2 gap-3">
                     <div>
-                      <Label className="text-xs">{isMultiDay ? 'Start time (day 1)' : 'Start time'}</Label>
+                      <Label className="text-xs">Start time</Label>
                       <Input
                         type="time"
                         value={customStart}
@@ -792,7 +830,7 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
                       />
                     </div>
                     <div>
-                      <Label className="text-xs">{isMultiDay ? 'End time (last day)' : 'End time'}</Label>
+                      <Label className="text-xs">End time</Label>
                       <Input
                         type="time"
                         value={customEnd}
@@ -803,13 +841,75 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
                   </div>
                 )}
 
+                {/* Recurring toggle — always visible */}
+                <div className="space-y-3 pt-1">
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="make-recurring"
+                      type="checkbox"
+                      checked={isRecurring}
+                      onChange={(e) => setIsRecurring(e.target.checked)}
+                      className="h-4 w-4 rounded border-border"
+                    />
+                    <Label htmlFor="make-recurring" className="cursor-pointer text-sm flex items-center gap-1.5">
+                      <Repeat className="h-3.5 w-3.5 text-muted-foreground" />
+                      Make this recurring
+                    </Label>
+                  </div>
+
+                  {isRecurring && (
+                    <div className="rounded-md border border-dashed px-3 py-3 space-y-3">
+                      <div>
+                        <Label className="text-xs">Frequency</Label>
+                        <Select
+                          value={recurringFrequency}
+                          onValueChange={(v) => setRecurringFrequency(v as 'DAILY' | 'WEEKLY' | 'MONTHLY')}
+                        >
+                          <SelectTrigger className="mt-1">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="DAILY">Daily</SelectItem>
+                            <SelectItem value="WEEKLY">Weekly</SelectItem>
+                            <SelectItem value="MONTHLY">Monthly</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {recurringFrequency === 'DAILY' && 'Repeats every day at the selected time'}
+                        {recurringFrequency === 'WEEKLY' && <>Repeats every <strong>{format(date, 'EEEE')}</strong> at the selected time</>}
+                        {recurringFrequency === 'MONTHLY' && <>Repeats on the <strong>{format(date, 'do')}</strong> of each month at the selected time</>}
+                      </p>
+                      <div>
+                        <Label className="text-xs">Repeat until</Label>
+                        <Input
+                          type="date"
+                          value={recurringLastDate}
+                          min={format(date, 'yyyy-MM-dd')}
+                          onChange={(e) => setRecurringLastDate(e.target.value)}
+                          className="mt-1"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+
                 <Button
-                  onClick={handleBook}
-                  disabled={createBooking.isPending}
+                  onClick={isRecurring ? () => createRecurring.mutate() : handleBook}
+                  disabled={
+                    isRecurring
+                      ? createRecurring.isPending || !recurringLastDate
+                      : createBooking.isPending
+                  }
                   className="w-full"
                 >
                   <CheckCircle className="mr-2 h-4 w-4" />
-                  {createBooking.isPending ? 'Booking…' : 'Book Desk'}
+                  {(isRecurring ? createRecurring : createBooking).isPending
+                    ? 'Booking…'
+                    : isRecurring
+                      ? `Book recurring ${categoryName}`
+                      : `Book ${categoryName}`
+                  }
                 </Button>
               </div>
             )}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   LeaseDocument,
   UserGroup,
   FloorSubscription,
+  RecurringBookingRule,
 } from '../types'
 
 const BASE = '/api/v1'
@@ -656,4 +657,19 @@ export const notificationsApi = {
   unreadCount: () => api.get<{ data: { count: number } }>('/notifications/unread-count'),
   markAllRead: () => api.patch<{ data: { ok: true } }>('/notifications/read-all'),
   markRead: (id: string) => api.patch<{ data: { ok: true } }>(`/notifications/${id}/read`),
+}
+
+// --- Recurring bookings ---
+export const recurringBookingsApi = {
+  list: () => api.get<{ data: RecurringBookingRule[] }>('/recurring-bookings'),
+  get: (id: string) => api.get<{ data: RecurringBookingRule }>(`/recurring-bookings/${id}`),
+  create: (body: {
+    assetId: string
+    dayOfWeek: number
+    startTime: string
+    endTime: string
+    firstDate: string
+    lastDate: string
+  }) => api.post<{ data: RecurringBookingRule }>('/recurring-bookings', body),
+  cancel: (id: string) => api.delete<{ data: { ok: true } }>(`/recurring-bookings/${id}`),
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -665,7 +665,8 @@ export const recurringBookingsApi = {
   get: (id: string) => api.get<{ data: RecurringBookingRule }>(`/recurring-bookings/${id}`),
   create: (body: {
     assetId: string
-    dayOfWeek: number
+    frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY'
+    dayOfWeek?: number
     startTime: string
     endTime: string
     firstDate: string

--- a/apps/web/src/pages/BookingsPage.tsx
+++ b/apps/web/src/pages/BookingsPage.tsx
@@ -12,8 +12,6 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -455,108 +453,6 @@ function BookingRow({ booking, showCancel }: { booking: Booking; showCancel: boo
 
 const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
-function CreateRecurringDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const qc = useQueryClient()
-  const [assetId, setAssetId] = useState('')
-  const [dayOfWeek, setDayOfWeek] = useState('')
-  const [startTime, setStartTime] = useState('')
-  const [endTime, setEndTime] = useState('')
-  const [firstDate, setFirstDate] = useState('')
-  const [lastDate, setLastDate] = useState('')
-
-  const { data: assetsData } = useQuery({
-    queryKey: ['assets-bookable'],
-    queryFn: () => assetsApi.list(),
-    select: (r) => r.data.filter((a) => a.isBookable && a.bookingStatus !== 'DISABLED'),
-  })
-
-  const create = useMutation({
-    mutationFn: () =>
-      recurringBookingsApi.create({
-        assetId,
-        dayOfWeek: Number(dayOfWeek),
-        startTime,
-        endTime,
-        firstDate,
-        lastDate,
-      }),
-    onSuccess: () => {
-      toast.success('Recurring booking series created')
-      qc.invalidateQueries({ queryKey: ['recurring-bookings'] })
-      onClose()
-    },
-    onError: (err: Error) => toast.error(err.message),
-  })
-
-  const canSubmit = assetId && dayOfWeek !== '' && startTime && endTime && firstDate && lastDate && !create.isPending
-
-  return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>New recurring booking</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4 py-2">
-          <div>
-            <Label>Asset</Label>
-            <Select value={assetId} onValueChange={setAssetId}>
-              <SelectTrigger className="mt-1.5">
-                <SelectValue placeholder="Select an asset…" />
-              </SelectTrigger>
-              <SelectContent>
-                {(assetsData ?? []).map((a) => (
-                  <SelectItem key={a.id} value={a.id}>
-                    {a.bookingLabel ?? a.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label>Day of week</Label>
-            <Select value={dayOfWeek} onValueChange={setDayOfWeek}>
-              <SelectTrigger className="mt-1.5">
-                <SelectValue placeholder="Select a day…" />
-              </SelectTrigger>
-              <SelectContent>
-                {DAY_NAMES.map((d, i) => (
-                  <SelectItem key={i} value={String(i)}>{d}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <Label>Start time</Label>
-              <Input type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} className="mt-1.5" />
-            </div>
-            <div>
-              <Label>End time</Label>
-              <Input type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} className="mt-1.5" />
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <Label>First date</Label>
-              <Input type="date" value={firstDate} onChange={(e) => setFirstDate(e.target.value)} className="mt-1.5" />
-            </div>
-            <div>
-              <Label>Last date</Label>
-              <Input type="date" value={lastDate} onChange={(e) => setLastDate(e.target.value)} className="mt-1.5" />
-            </div>
-          </div>
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={create.isPending}>Cancel</Button>
-          <Button onClick={() => create.mutate()} disabled={!canSubmit}>
-            {create.isPending ? 'Creating…' : 'Create series'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
 function RecurringRuleCard({ rule }: { rule: RecurringBookingRule }) {
   const qc = useQueryClient()
 
@@ -591,7 +487,9 @@ function RecurringRuleCard({ rule }: { rule: RecurringBookingRule }) {
             )}
             <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
               <Repeat className="h-3 w-3 shrink-0" />
-              Every {DAY_NAMES[rule.dayOfWeek]}, {rule.startTime}–{rule.endTime}
+              {rule.frequency === 'DAILY' && `Every day, ${rule.startTime}–${rule.endTime}`}
+              {rule.frequency === 'WEEKLY' && rule.dayOfWeek != null && `Every ${DAY_NAMES[rule.dayOfWeek]}, ${rule.startTime}–${rule.endTime}`}
+              {rule.frequency === 'MONTHLY' && `Monthly, ${rule.startTime}–${rule.endTime}`}
             </p>
             <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
               <Calendar className="h-3 w-3 shrink-0" />
@@ -634,42 +532,26 @@ function RecurringRuleCard({ rule }: { rule: RecurringBookingRule }) {
 }
 
 function RecurringBookingsSection() {
-  const [createOpen, setCreateOpen] = useState(false)
-
   const { data, isLoading } = useQuery({
     queryKey: ['recurring-bookings'],
     queryFn: () => recurringBookingsApi.list(),
     select: (r) => r.data,
   })
 
+  if (isLoading) return <div className="mb-8"><Skeleton className="h-20 w-full" /></div>
+  if (!data || data.length === 0) return null
+
   return (
     <div className="mb-8">
-      <div className="flex items-center justify-between gap-2 mb-3">
-        <div className="flex items-center gap-2">
-          <Repeat className="h-4 w-4 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Recurring Bookings</h2>
-        </div>
-        <Button size="sm" variant="outline" className="h-8 text-xs gap-1.5" onClick={() => setCreateOpen(true)}>
-          <CalendarPlus className="h-3.5 w-3.5" />
-          New series
-        </Button>
+      <div className="flex items-center gap-2 mb-3">
+        <Repeat className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-base font-semibold">Recurring Bookings</h2>
       </div>
-
-      {isLoading && <Skeleton className="h-20 w-full" />}
-
-      {!isLoading && (!data || data.length === 0) && (
-        <p className="text-sm text-muted-foreground py-4 text-center">No recurring bookings</p>
-      )}
-
-      {!isLoading && data && data.length > 0 && (
-        <div className="space-y-3">
-          {data.map((rule) => (
-            <RecurringRuleCard key={rule.id} rule={rule} />
-          ))}
-        </div>
-      )}
-
-      {createOpen && <CreateRecurringDialog open={createOpen} onClose={() => setCreateOpen(false)} />}
+      <div className="space-y-3">
+        {data.map((rule) => (
+          <RecurringRuleCard key={rule.id} rule={rule} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/BookingsPage.tsx
+++ b/apps/web/src/pages/BookingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { parseISO, isToday } from 'date-fns'
-import { Calendar, MapPin, Clock, Trash2, Pencil, CalendarPlus, X, Armchair } from 'lucide-react'
+import { Calendar, MapPin, Clock, Trash2, Pencil, CalendarPlus, X, Armchair, Repeat } from 'lucide-react'
 import { useMyBookings, useCancelBooking, useUpdateBooking } from '@/hooks/useBookings'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,8 +34,8 @@ import {
 } from '@/components/ui/dialog'
 import { formatDateRange, formatDate } from '@/lib/utils'
 import { DateTimeLocalInput } from '@/components/ui/date-time-input'
-import { assetsApi, type MyAssignment, type AvailabilityWindow } from '@/lib/api'
-import type { Booking } from '@/types'
+import { assetsApi, recurringBookingsApi, type MyAssignment, type AvailabilityWindow } from '@/lib/api'
+import type { Booking, RecurringBookingRule } from '@/types'
 
 type Tab = 'upcoming' | 'past' | 'all'
 
@@ -449,6 +451,229 @@ function BookingRow({ booking, showCancel }: { booking: Booking; showCancel: boo
   )
 }
 
+// ─── Recurring bookings ───────────────────────────────────────────────────────
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+function CreateRecurringDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const qc = useQueryClient()
+  const [assetId, setAssetId] = useState('')
+  const [dayOfWeek, setDayOfWeek] = useState('')
+  const [startTime, setStartTime] = useState('')
+  const [endTime, setEndTime] = useState('')
+  const [firstDate, setFirstDate] = useState('')
+  const [lastDate, setLastDate] = useState('')
+
+  const { data: assetsData } = useQuery({
+    queryKey: ['assets-bookable'],
+    queryFn: () => assetsApi.list(),
+    select: (r) => r.data.filter((a) => a.isBookable && a.bookingStatus !== 'DISABLED'),
+  })
+
+  const create = useMutation({
+    mutationFn: () =>
+      recurringBookingsApi.create({
+        assetId,
+        dayOfWeek: Number(dayOfWeek),
+        startTime,
+        endTime,
+        firstDate,
+        lastDate,
+      }),
+    onSuccess: () => {
+      toast.success('Recurring booking series created')
+      qc.invalidateQueries({ queryKey: ['recurring-bookings'] })
+      onClose()
+    },
+    onError: (err: Error) => toast.error(err.message),
+  })
+
+  const canSubmit = assetId && dayOfWeek !== '' && startTime && endTime && firstDate && lastDate && !create.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>New recurring booking</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div>
+            <Label>Asset</Label>
+            <Select value={assetId} onValueChange={setAssetId}>
+              <SelectTrigger className="mt-1.5">
+                <SelectValue placeholder="Select an asset…" />
+              </SelectTrigger>
+              <SelectContent>
+                {(assetsData ?? []).map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    {a.bookingLabel ?? a.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Day of week</Label>
+            <Select value={dayOfWeek} onValueChange={setDayOfWeek}>
+              <SelectTrigger className="mt-1.5">
+                <SelectValue placeholder="Select a day…" />
+              </SelectTrigger>
+              <SelectContent>
+                {DAY_NAMES.map((d, i) => (
+                  <SelectItem key={i} value={String(i)}>{d}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label>Start time</Label>
+              <Input type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} className="mt-1.5" />
+            </div>
+            <div>
+              <Label>End time</Label>
+              <Input type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} className="mt-1.5" />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label>First date</Label>
+              <Input type="date" value={firstDate} onChange={(e) => setFirstDate(e.target.value)} className="mt-1.5" />
+            </div>
+            <div>
+              <Label>Last date</Label>
+              <Input type="date" value={lastDate} onChange={(e) => setLastDate(e.target.value)} className="mt-1.5" />
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={create.isPending}>Cancel</Button>
+          <Button onClick={() => create.mutate()} disabled={!canSubmit}>
+            {create.isPending ? 'Creating…' : 'Create series'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RecurringRuleCard({ rule }: { rule: RecurringBookingRule }) {
+  const qc = useQueryClient()
+
+  const cancel = useMutation({
+    mutationFn: () => recurringBookingsApi.cancel(rule.id),
+    onSuccess: () => {
+      toast.success('Recurring series cancelled')
+      qc.invalidateQueries({ queryKey: ['recurring-bookings'] })
+    },
+    onError: (err: Error) => toast.error(err.message),
+  })
+
+  const assetLabel = rule.asset?.bookingLabel ?? rule.asset?.name ?? 'Unknown asset'
+  const location = [rule.asset?.floor?.building.name, rule.asset?.floor?.name].filter(Boolean).join(' › ')
+  const upcomingCount = rule.bookings?.length ?? rule._count?.bookings ?? 0
+
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <p className="font-medium truncate">{assetLabel}</p>
+              <Badge variant={rule.status === 'ACTIVE' ? 'default' : 'destructive'} className="shrink-0 text-xs">
+                {rule.status}
+              </Badge>
+            </div>
+            {location && (
+              <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
+                <MapPin className="h-3 w-3 shrink-0" />{location}
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+              <Repeat className="h-3 w-3 shrink-0" />
+              Every {DAY_NAMES[rule.dayOfWeek]}, {rule.startTime}–{rule.endTime}
+            </p>
+            <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+              <Calendar className="h-3 w-3 shrink-0" />
+              {formatDate(rule.firstDate)} → {formatDate(rule.lastDate)}
+              {upcomingCount > 0 && <span className="ml-1">({upcomingCount} upcoming)</span>}
+            </p>
+          </div>
+
+          {rule.status === 'ACTIVE' && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive">
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Cancel recurring series?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    All future bookings in this series for <strong>{assetLabel}</strong> will be cancelled.
+                    Past bookings are not affected.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep series</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => cancel.mutate()}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Cancel series
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function RecurringBookingsSection() {
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['recurring-bookings'],
+    queryFn: () => recurringBookingsApi.list(),
+    select: (r) => r.data,
+  })
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <div className="flex items-center gap-2">
+          <Repeat className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-base font-semibold">Recurring Bookings</h2>
+        </div>
+        <Button size="sm" variant="outline" className="h-8 text-xs gap-1.5" onClick={() => setCreateOpen(true)}>
+          <CalendarPlus className="h-3.5 w-3.5" />
+          New series
+        </Button>
+      </div>
+
+      {isLoading && <Skeleton className="h-20 w-full" />}
+
+      {!isLoading && (!data || data.length === 0) && (
+        <p className="text-sm text-muted-foreground py-4 text-center">No recurring bookings</p>
+      )}
+
+      {!isLoading && data && data.length > 0 && (
+        <div className="space-y-3">
+          {data.map((rule) => (
+            <RecurringRuleCard key={rule.id} rule={rule} />
+          ))}
+        </div>
+      )}
+
+      {createOpen && <CreateRecurringDialog open={createOpen} onClose={() => setCreateOpen(false)} />}
+    </div>
+  )
+}
+
 function BookingList({ tab }: { tab: Tab }) {
   const status = tab === 'upcoming' ? 'upcoming' : tab === 'past' ? 'past' : 'all'
   const { data, isLoading } = useMyBookings(status)
@@ -493,6 +718,7 @@ export default function BookingsPage() {
       </div>
 
       <MyAssignedDesks />
+      <RecurringBookingsSection />
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
         <TabsList className="mb-4">

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -142,6 +142,30 @@ export interface AssetWithStatus extends Omit<Asset, 'bookingStatus'> {
 /** @deprecated Use AssetWithStatus instead */
 export type DeskWithStatus = AssetWithStatus
 
+export type RecurringRuleStatus = 'ACTIVE' | 'CANCELLED'
+
+export interface RecurringBookingRule {
+  id: string
+  userId: string
+  assetId: string
+  dayOfWeek: number
+  startTime: string
+  endTime: string
+  firstDate: string
+  lastDate: string
+  status: RecurringRuleStatus
+  createdAt: string
+  updatedAt: string
+  asset?: {
+    id: string
+    name: string
+    bookingLabel?: string | null
+    floor?: { name: string; building: { name: string } } | null
+  }
+  bookings?: Array<{ id: string; startsAt: string; endsAt: string; status?: string }>
+  _count?: { bookings: number }
+}
+
 export interface Booking {
   id: string
   userId: string
@@ -150,6 +174,7 @@ export interface Booking {
   endsAt: string
   status: BookingStatus
   notes?: string
+  recurringRuleId?: string | null
   user?: User
   asset?: Asset & {
     floor?: Floor & { building?: Building }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -143,12 +143,14 @@ export interface AssetWithStatus extends Omit<Asset, 'bookingStatus'> {
 export type DeskWithStatus = AssetWithStatus
 
 export type RecurringRuleStatus = 'ACTIVE' | 'CANCELLED'
+export type RecurringFrequency = 'DAILY' | 'WEEKLY' | 'MONTHLY'
 
 export interface RecurringBookingRule {
   id: string
   userId: string
   assetId: string
-  dayOfWeek: number
+  frequency: RecurringFrequency
+  dayOfWeek: number | null
   startTime: string
   endTime: string
   firstDate: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -42,6 +42,17 @@ export enum BookingStatus {
   COMPLETED = 'COMPLETED',
 }
 
+export enum RecurringRuleStatus {
+  ACTIVE = 'ACTIVE',
+  CANCELLED = 'CANCELLED',
+}
+
+export enum RecurringFrequency {
+  DAILY = 'DAILY',
+  WEEKLY = 'WEEKLY',
+  MONTHLY = 'MONTHLY',
+}
+
 export enum QueueEntryStatus {
   WAITING = 'WAITING',
   PROMOTED = 'PROMOTED',
@@ -96,6 +107,7 @@ export interface Organisation {
   id: string
   name: string
   slug: string
+  maxRecurringBookingWeeks: number
   createdAt: Date
   updatedAt: Date
 }
@@ -203,6 +215,22 @@ export interface Booking {
   status: BookingStatus
   notes: string | null
   reminderSentAt: Date | null
+  recurringRuleId: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface RecurringBookingRule {
+  id: string
+  userId: string
+  assetId: string
+  frequency: RecurringFrequency
+  dayOfWeek: number | null
+  startTime: string
+  endTime: string
+  firstDate: Date
+  lastDate: Date
+  status: RecurringRuleStatus
   createdAt: Date
   updatedAt: Date
 }


### PR DESCRIPTION
## Summary

- Adds `RecurringBookingRule` Prisma model with `firstDate`/`lastDate` (`@db.Date`) and `dayOfWeek`/`startTime`/`endTime` fields
- `maxRecurringBookingWeeks` setting on `Organisation` (default 12)
- `POST /api/v1/recurring-bookings` — atomic transaction: conflict-checks every slot, then creates rule + all bookings; rejects entire series on any conflict
- `GET /recurring-bookings`, `GET /recurring-bookings/:id`, `DELETE /recurring-bookings/:id` — cancel cancels rule + all future CONFIRMED bookings
- Frontend: `RecurringBookingsSection` on the Bookings page — create series dialog (asset selector, day-of-week, times, date range) and cancel confirmation per rule
- `RecurringRuleStatus` type + `RecurringBookingRule` interface in `packages/shared` and `apps/web/src/types`

## Test plan

- [x] Create a recurring booking for a weekday across a 4-week range — verify N bookings materialise
- [ ] Attempt creation where one slot conflicts — verify entire series is rejected with `BOOKING_CONFLICT` and no bookings are created
- [ ] Cancel a rule — verify future CONFIRMED bookings are cancelled, past/completed bookings unchanged
- [ ] Verify `maxRecurringBookingWeeks` org setting is enforced
- [ ] Verify RESTRICTED assets enforce allow-list for recurring bookings
- [ ] Build passes (`npm run build`)