### PR TITLE
feat: recurring bookings with daily/weekly/monthly frequency

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: Roomer CodeQL Configuration
+
+# Note on js/missing-rate-limiting false positives:
+# This project uses @fastify/rate-limit registered globally in app.ts (max: 300 req/min)
+# and per-route overrides via `config: { rateLimit: { max: N } }` in route options.
+# CodeQL's js/missing-rate-limiting query only recognises Express app.use(rateLimit())
+# patterns and does not detect Fastify plugin registration or per-route config objects.
+# Affected routes carry `// lgtm[js/missing-rate-limiting]` inline suppressions.

--- a/apps/api/prisma/migrations/20260502000000_add_recurring_bookings/migration.sql
+++ b/apps/api/prisma/migrations/20260502000000_add_recurring_bookings/migration.sql
@@ -1,0 +1,40 @@
+-- CreateEnum
+CREATE TYPE "RecurringRuleStatus" AS ENUM ('ACTIVE', 'CANCELLED');
+
+-- AlterTable: Organisation
+ALTER TABLE "Organisation" ADD COLUMN "maxRecurringBookingWeeks" INTEGER NOT NULL DEFAULT 12;
+
+-- AlterTable: Booking
+ALTER TABLE "Booking" ADD COLUMN "recurringRuleId" TEXT;
+
+-- CreateTable
+CREATE TABLE "RecurringBookingRule" (
+    "id"          TEXT NOT NULL,
+    "userId"      TEXT NOT NULL,
+    "assetId"     TEXT NOT NULL,
+    "dayOfWeek"   INTEGER NOT NULL,
+    "startTime"   TEXT NOT NULL,
+    "endTime"     TEXT NOT NULL,
+    "firstDate"   DATE NOT NULL,
+    "lastDate"    DATE NOT NULL,
+    "status"      "RecurringRuleStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"   TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecurringBookingRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RecurringBookingRule_userId_idx" ON "RecurringBookingRule"("userId");
+CREATE INDEX "RecurringBookingRule_assetId_idx" ON "RecurringBookingRule"("assetId");
+CREATE INDEX "Booking_recurringRuleId_idx" ON "Booking"("recurringRuleId");
+
+-- AddForeignKey
+ALTER TABLE "RecurringBookingRule" ADD CONSTRAINT "RecurringBookingRule_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "RecurringBookingRule" ADD CONSTRAINT "RecurringBookingRule_assetId_fkey"
+    FOREIGN KEY ("assetId") REFERENCES "Asset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Booking" ADD CONSTRAINT "Booking_recurringRuleId_fkey"
+    FOREIGN KEY ("recurringRuleId") REFERENCES "RecurringBookingRule"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/src/routes/leases.ts
+++ b/apps/api/src/routes/leases.ts
@@ -322,6 +322,7 @@ export async function leaseRoutes(fastify: FastifyInstance): Promise<void> {
   })
 
   // DELETE /leases/:id/documents/:docId — delete document (SUPER_ADMIN or building admin)
+  // lgtm[js/missing-rate-limiting] - False positive: @fastify/rate-limit applied globally (app.ts) and per-route via config.rateLimit
   fastify.delete('/:id/documents/:docId', { preHandler: [requireAuth], config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { id, docId } = request.params as { id: string; docId: string }
 


### PR DESCRIPTION
## Summary

- Adds recurring booking support — users can create a daily, weekly, or monthly booking series directly from the floor plan asset panel
- Moves recurring booking creation out of My Bookings (now display-only) into the asset panel with a "Make this recurring" checkbox and frequency selector
- Dynamically renames the book button to match the asset's category name (e.g. "Book Desk", "Book Meeting Room")
- Adds `frequency` (DAILY/WEEKLY/MONTHLY) to the `RecurringBookingRule` model, with MONTHLY occurrence clamping for shorter months
- Registers missing Swagger tags for `Subscriptions` and `Recurring Bookings` routes
- Suppresses CodeQL `js/missing-rate-limiting` false positive on the leases document delete route; adds `.github/codeql/codeql-config.yml` documenting that `@fastify/rate-limit` is applied globally and per-route (CodeQL only recognises Express patterns)