### PR TITLE
fix(ci): generate Prisma client before build in dependency PR workflow

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma client
+        run: pnpm --filter @roomer/api exec prisma generate
+
       - name: Build (all packages)
         run: pnpm turbo build


### PR DESCRIPTION
## Summary

- Adds `prisma generate` step between dependency install and `turbo build` in the dependency PR build workflow
- Without this, `tsc` fails with `Module '"@prisma/client"' has no exported member 'PrismaClient'` because the generated client types don't exist in a fresh CI environment

## Test plan

- [x] Merge this PR
- [ ] Verify the next Dependabot PR (e.g. #141) build check passes