### PR TITLE
feat: building admin route access (#73)

### DIFF
--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma.js'
 import { GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
-import { requireGlobalRole, getManagedBuildingIds } from '../middleware/requireRole.js'
+import { getManagedBuildingIds } from '../middleware/requireRole.js'
 import { z } from 'zod'
 
 const analyticsQuerySchema = z.object({
@@ -235,20 +235,39 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /summary — KPI summary stats
+  // GET /summary — KPI summary stats (SUPER_ADMIN or building admin scoped to managed buildings)
   fastify.get(
     '/summary',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) return reply.status(400).send({ error: { message: 'Invalid query', code: 'VALIDATION_ERROR' } })
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
 
       const defaults = defaultDateRange()
       const startDate = parseDateParam(result.data.startDate, 'T00:00:00.000Z', defaults.startDate)
       const endDate = parseDateParam(result.data.endDate, 'T23:59:59.999Z', defaults.endDate)
       const workingDays = countWorkingDays(startDate, endDate)
 
-      const bookingWhere: Record<string, unknown> = { startsAt: { gte: startDate, lte: endDate } }
+      const bookingBuildingFilter = !isSuperAdmin
+        ? { asset: { floor: { buildingId: { in: managedBuildingIds } } } }
+        : {}
+      const assetBuildingFilter = !isSuperAdmin
+        ? { floor: { buildingId: { in: managedBuildingIds } } }
+        : {}
+      const queueBuildingFilter = !isSuperAdmin
+        ? { asset: { floor: { buildingId: { in: managedBuildingIds } } } }
+        : {}
+
+      const bookingWhere: Record<string, unknown> = { startsAt: { gte: startDate, lte: endDate }, ...bookingBuildingFilter }
 
       const [confirmed, cancelled, completed, uniqueBookers, bookableDesks, assignedDesks, disabledDesks, queueDepth] = await Promise.all([
         prisma.booking.count({ where: { ...bookingWhere, status: 'CONFIRMED' } }),
@@ -260,10 +279,10 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
           distinct: ['userId'],
         }),
         // OPEN + RESTRICTED = freely bookable assets
-        prisma.asset.count({ where: { isBookable: true, bookingStatus: { in: ['OPEN', 'RESTRICTED'] } } }),
-        prisma.asset.count({ where: { isBookable: true, bookingStatus: 'ASSIGNED' } }),
-        prisma.asset.count({ where: { isBookable: true, bookingStatus: 'DISABLED' } }),
-        prisma.queueEntry.count({ where: { status: 'WAITING' } }),
+        prisma.asset.count({ where: { isBookable: true, bookingStatus: { in: ['OPEN', 'RESTRICTED'] }, ...assetBuildingFilter } }),
+        prisma.asset.count({ where: { isBookable: true, bookingStatus: 'ASSIGNED', ...assetBuildingFilter } }),
+        prisma.asset.count({ where: { isBookable: true, bookingStatus: 'DISABLED', ...assetBuildingFilter } }),
+        prisma.queueEntry.count({ where: { status: 'WAITING', ...queueBuildingFilter } }),
       ])
 
       const totalDesks = bookableDesks + assignedDesks + disabledDesks
@@ -294,22 +313,35 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /status-breakdown — booking counts by status
+  // GET /status-breakdown — booking counts by status (SUPER_ADMIN or building admin scoped to managed buildings)
   fastify.get(
     '/status-breakdown',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) return reply.status(400).send({ error: { message: 'Invalid query', code: 'VALIDATION_ERROR' } })
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
 
       const defaults = defaultDateRange()
       const startDate = result.data.startDate ? new Date(result.data.startDate + 'T00:00:00.000Z') : defaults.startDate
       const endDate = result.data.endDate ? new Date(result.data.endDate + 'T23:59:59.999Z') : defaults.endDate
 
+      const buildingFilter = !isSuperAdmin
+        ? { asset: { floor: { buildingId: { in: managedBuildingIds } } } }
+        : {}
+
       const [confirmed, cancelled, completed] = await Promise.all([
-        prisma.booking.count({ where: { startsAt: { gte: startDate, lte: endDate }, status: 'CONFIRMED' } }),
-        prisma.booking.count({ where: { startsAt: { gte: startDate, lte: endDate }, status: 'CANCELLED' } }),
-        prisma.booking.count({ where: { startsAt: { gte: startDate, lte: endDate }, status: 'COMPLETED' } }),
+        prisma.booking.count({ where: { startsAt: { gte: startDate, lte: endDate }, status: 'CONFIRMED', ...buildingFilter } }),
+        prisma.booking.count({ where: { startsAt: { gte: startDate, lte: endDate }, status: 'CANCELLED', ...buildingFilter } }),
+        prisma.booking.count({ where: { startsAt: { gte: startDate, lte: endDate }, status: 'COMPLETED', ...buildingFilter } }),
       ])
 
       return reply.status(200).send({
@@ -322,28 +354,53 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // GET /peak-days — bookings grouped by day of week
+  // GET /peak-days — bookings grouped by day of week (SUPER_ADMIN or building admin scoped to managed buildings)
   fastify.get(
     '/peak-days',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = analyticsQuerySchema.safeParse(request.query)
       if (!result.success) return reply.status(400).send({ error: { message: 'Invalid query', code: 'VALIDATION_ERROR' } })
+
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedBuildingIds: string[] = []
+      if (!isSuperAdmin) {
+        managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+      }
 
       const defaults = defaultDateRange()
       const startDate = result.data.startDate ? new Date(result.data.startDate + 'T00:00:00.000Z') : defaults.startDate
       const endDate = result.data.endDate ? new Date(result.data.endDate + 'T23:59:59.999Z') : defaults.endDate
 
       type DowRow = { dow: string; count: bigint }
-      const rows = await prisma.$queryRaw<DowRow[]>`
-        SELECT EXTRACT(DOW FROM "startsAt") AS dow, COUNT(*)::bigint AS count
-        FROM "Booking"
-        WHERE "startsAt" >= ${startDate}
-          AND "startsAt" <= ${endDate}
-          AND status = 'CONFIRMED'
-        GROUP BY EXTRACT(DOW FROM "startsAt")
-        ORDER BY dow ASC
-      `
+      let rows: DowRow[]
+      if (isSuperAdmin) {
+        rows = await prisma.$queryRaw<DowRow[]>`
+          SELECT EXTRACT(DOW FROM "startsAt") AS dow, COUNT(*)::bigint AS count
+          FROM "Booking"
+          WHERE "startsAt" >= ${startDate}
+            AND "startsAt" <= ${endDate}
+            AND status = 'CONFIRMED'
+          GROUP BY EXTRACT(DOW FROM "startsAt")
+          ORDER BY dow ASC
+        `
+      } else {
+        rows = await prisma.$queryRaw<DowRow[]>`
+          SELECT EXTRACT(DOW FROM b."startsAt") AS dow, COUNT(*)::bigint AS count
+          FROM "Booking" b
+          JOIN "Asset" a ON a.id = b."assetId"
+          JOIN "Floor" f ON f.id = a."floorId"
+          WHERE b."startsAt" >= ${startDate}
+            AND b."startsAt" <= ${endDate}
+            AND b.status = 'CONFIRMED'
+            AND f."buildingId" = ANY(${managedBuildingIds})
+          GROUP BY EXTRACT(DOW FROM b."startsAt")
+          ORDER BY dow ASC
+        `
+      }
 
       const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
       const countByDow: Record<number, number> = {}

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -884,7 +884,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
         })
       }
 
-      // Authorization: super admin can edit any asset; floor managers can edit assets on their floor
+      // Authorization: super admin can edit any asset; floor managers and building admins can edit assets on their floors
       const isAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
       if (!isAdmin) {
         const existing = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
@@ -894,20 +894,8 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
         if (!existing.floorId) {
           return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
         }
-        const directRole = await prisma.userResourceRole.findFirst({
-          where: { userId: request.user.id, scopeType: 'FLOOR', floorId: existing.floorId, role: 'FLOOR_MANAGER' },
-        })
-        const groupRole = !directRole
-          ? await prisma.groupResourceRole.findFirst({
-              where: {
-                scopeType: 'FLOOR',
-                floorId: existing.floorId,
-                role: 'FLOOR_MANAGER',
-                group: { members: { some: { userId: request.user.id } } },
-              },
-            })
-          : null
-        if (!directRole && !groupRole) {
+        const canManage = await isFloorManagerForFloor(request.user.id, existing.floorId)
+        if (!canManage) {
           return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
         }
       }

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { prisma } from '../lib/prisma.js'
 import { GlobalRole, BookableStatus, bulkUpdateAssetPositionsSchema, NotificationType } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
-import { requireGlobalRole, getManagedFloorIds, isFloorManagerForFloor } from '../middleware/requireRole.js'
+import { requireGlobalRole, getManagedFloorIds, getManagedBuildingIds, isFloorManagerForFloor } from '../middleware/requireRole.js'
 import { enqueueNotification, fanOutFloorAvailable } from '../lib/queue.js'
 import { randomUUID } from 'crypto'
 import { z } from 'zod'
@@ -101,7 +101,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /bulk-import — create multiple bookable assets and place them on a floor
   fastify.post(
     '/bulk-import',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = bulkImportSchema.safeParse(request.body)
       if (!result.success) {
@@ -118,6 +118,11 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
       })
       if (!floor) {
         return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+      }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const canManage = await isFloorManagerForFloor(request.user.id, floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
 
       const created: { id: string; name: string }[] = []
@@ -622,12 +627,17 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // DELETE /user-assignments/by-floor/:floorId — clear all permanent assignments on a floor
   fastify.delete(
     '/user-assignments/by-floor/:floorId',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { floorId } = request.params as { floorId: string }
       const floor = await prisma.floor.findUnique({ where: { id: floorId } })
       if (!floor) {
         return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+      }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const canManage = await isFloorManagerForFloor(request.user.id, floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
       const assets = await prisma.asset.findMany({ where: { floorId }, select: { id: true } })
       const assetIds = assets.map((a) => a.id)
@@ -648,7 +658,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /user-assignments/bulk — bulk create/update permanent user assignments
   fastify.post(
     '/user-assignments/bulk',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const bodySchema = z.object({
         rows: z.array(z.object({
@@ -667,20 +677,37 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
       let assigned = 0
       const errors: Array<{ row: number; assetId: string; userEmail: string; error: string }> = []
 
+      const isAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let managedFloorIds: Set<string> = new Set()
+      if (!isAdmin) {
+        const ids = await getManagedFloorIds(request.user.id)
+        if (ids.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        managedFloorIds = new Set(ids)
+      }
+
       // Pre-fetch all referenced assets and users in two batch queries
       const allAssetIds = [...new Set(rows.map((r) => r.assetId))]
       const allEmails = [...new Set(rows.map((r) => r.userEmail))]
       const [assetRows, userRows] = await Promise.all([
-        prisma.asset.findMany({ where: { id: { in: allAssetIds } }, select: { id: true } }),
+        prisma.asset.findMany({ where: { id: { in: allAssetIds } }, select: { id: true, floorId: true } }),
         prisma.user.findMany({ where: { email: { in: allEmails } }, select: { id: true, email: true } }),
       ])
-      const assetIds = new Set(assetRows.map((a) => a.id))
+      const assetFloorMap = new Map(assetRows.map((a) => [a.id, a.floorId]))
       const userByEmail = new Map(userRows.map((u) => [u.email, u.id]))
 
       for (let i = 0; i < rows.length; i++) {
         const { assetId, userEmail, isPrimary } = rows[i]
         try {
-          if (!assetIds.has(assetId)) { errors.push({ row: i + 1, assetId, userEmail, error: 'Asset not found' }); continue }
+          if (!assetFloorMap.has(assetId)) { errors.push({ row: i + 1, assetId, userEmail, error: 'Asset not found' }); continue }
+          if (!isAdmin) {
+            const floorId = assetFloorMap.get(assetId)
+            if (!floorId || !managedFloorIds.has(floorId)) {
+              errors.push({ row: i + 1, assetId, userEmail, error: 'Asset not on a managed floor' })
+              continue
+            }
+          }
           const userId = userByEmail.get(userEmail)
           if (!userId) { errors.push({ row: i + 1, assetId, userEmail, error: 'User not found' }); continue }
           if (isPrimary) {
@@ -708,14 +735,27 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // GET /user-assignments/export — export asset+assignment data for CSV generation
   fastify.get(
     '/user-assignments/export',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const queryResult = z.object({ buildingId: z.string().cuid().optional() }).safeParse(request.query)
       if (!queryResult.success) {
         return reply.status(400).send({ error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR' } })
       }
       const { buildingId } = queryResult.data
-      const whereClause = buildingId ? { floor: { building: { id: buildingId } } } : {}
+      const isSuperAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+      let whereClause: Record<string, unknown> = buildingId ? { floor: { building: { id: buildingId } } } : {}
+      if (!isSuperAdmin) {
+        const managedBuildingIds = await getManagedBuildingIds(request.user.id)
+        if (managedBuildingIds.length === 0) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (buildingId && !managedBuildingIds.includes(buildingId)) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        if (!buildingId) {
+          whereClause = { floor: { buildingId: { in: managedBuildingIds } } }
+        }
+      }
       const assets = await prisma.asset.findMany({
         where: whereClause,
         select: {
@@ -782,16 +822,24 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(200).send({ data: asset })
   })
 
-  // POST / — create asset (admin)
+  // POST / — create asset (SUPER_ADMIN, or floor manager/building admin when floorId is provided)
   fastify.post(
     '/',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = createAssetSchema.safeParse(request.body)
       if (!result.success) {
         return reply.status(400).send({
           error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() },
         })
+      }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!result.data.floorId) {
+          return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        }
+        const canManage = await isFloorManagerForFloor(request.user.id, result.data.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
 
       const category = await prisma.assetCategory.findUnique({
@@ -886,12 +934,20 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // DELETE /:id — delete asset (admin)
+  // DELETE /:id — delete asset (SUPER_ADMIN or floor manager/building admin for assets on managed floors)
   fastify.delete(
     '/:id',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const existing = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
+        if (!existing) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+        if (!existing.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, existing.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
 
       try {
         await prisma.asset.delete({ where: { id } })
@@ -994,12 +1050,17 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // GET /:id/user-assignments — list permanent user assignments
   fastify.get(
     '/:id/user-assignments',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
       const asset = await prisma.asset.findUnique({ where: { id } })
       if (!asset) {
         return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+      }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
       const assignments = await prisma.assetUserAssignment.findMany({
         where: { assetId: id },
@@ -1015,7 +1076,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /:id/user-assignments — add permanent user
   fastify.post(
     '/:id/user-assignments',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
       const schema = z.object({ userId: z.string().min(1), isPrimary: z.boolean().default(false) })
@@ -1028,6 +1089,11 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
       const asset = await prisma.asset.findUnique({ where: { id } })
       if (!asset) {
         return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+      }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
       const user = await prisma.user.findUnique({ where: { id: result.data.userId } })
       if (!user) {
@@ -1053,9 +1119,16 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // DELETE /:id/user-assignments/:userId — remove permanent user
   fastify.delete(
     '/:id/user-assignments/:userId',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id, userId } = request.params as { id: string; userId: string }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const asset = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
+        if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
       try {
         await prisma.assetUserAssignment.delete({
           where: { assetId_userId: { assetId: id, userId } },
@@ -1074,9 +1147,16 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // PATCH /:id/user-assignments/:userId/primary — set as primary
   fastify.patch(
     '/:id/user-assignments/:userId/primary',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id, userId } = request.params as { id: string; userId: string }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const asset = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
+        if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
       const existing = await prisma.assetUserAssignment.findUnique({
         where: { assetId_userId: { assetId: id, userId } },
       })
@@ -1100,13 +1180,18 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // GET /:id/history — assignment history
   fastify.get(
     '/:id/history',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
 
       const asset = await prisma.asset.findUnique({ where: { id } })
       if (!asset) {
         return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+      }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
 
       const history = await prisma.assetAssignment.findMany({
@@ -1124,7 +1209,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /:id/allow-list — add userId to allow list (bookable assets)
   fastify.post(
     '/:id/allow-list',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
       const result = addToAllowListSchema.safeParse(request.body)
@@ -1137,6 +1222,11 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
       const asset = await prisma.asset.findUnique({ where: { id } })
       if (!asset) {
         return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+      }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
 
       const user = await prisma.user.findUnique({ where: { id: result.data.userId } })
@@ -1160,9 +1250,17 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // DELETE /:id/allow-list/:userId
   fastify.delete(
     '/:id/allow-list/:userId',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id, userId } = request.params as { id: string; userId: string }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const asset = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
+        if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
 
       try {
         await prisma.assetAllowList.delete({
@@ -1180,13 +1278,18 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // GET /:id/allow-list — list allow-list entries
   fastify.get(
     '/:id/allow-list',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
 
       const asset = await prisma.asset.findUnique({ where: { id } })
       if (!asset) {
         return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+      }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
 
       const entries = await prisma.assetAllowList.findMany({
@@ -1202,9 +1305,16 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // GET /:id/zones — list additional zone memberships
   fastify.get(
     '/:id/zones',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const asset = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
+        if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
       const assetZones = await prisma.assetZone.findMany({
         where: { assetId: id },
         include: { zone: { select: { id: true, name: true, colour: true } } },
@@ -1217,7 +1327,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /:id/zones — add asset to an additional zone
   fastify.post(
     '/:id/zones',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
       const result = addZoneSchema.safeParse(request.body)
@@ -1233,6 +1343,12 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
       ])
       if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
       if (!zone) return reply.status(404).send({ error: { message: 'Zone not found', code: 'NOT_FOUND' } })
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
 
       // Prevent adding the primary zone as an additional zone
       if (asset.primaryZoneId === result.data.zoneId) {
@@ -1257,9 +1373,17 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
   // DELETE /:id/zones/:zoneId — remove asset from additional zone
   fastify.delete(
     '/:id/zones/:zoneId',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id, zoneId } = request.params as { id: string; zoneId: string }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const asset = await prisma.asset.findUnique({ where: { id }, select: { floorId: true } })
+        if (!asset) return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+        if (!asset.floorId) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+        const canManage = await isFloorManagerForFloor(request.user.id, asset.floorId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
 
       try {
         await prisma.assetZone.delete({ where: { assetId_zoneId: { assetId: id, zoneId } } })

--- a/apps/api/src/routes/buildings.ts
+++ b/apps/api/src/routes/buildings.ts
@@ -25,20 +25,25 @@ export async function buildingRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.status(200).send({ data: buildings })
     }
 
-    // For regular users: return open buildings plus any restricted buildings
-    // their groups grant access to.
-    const userGroupIds = (
-      await prisma.userGroupMember.findMany({
+    // For regular users: return open buildings, group-accessible buildings,
+    // and any buildings where this user is a building admin.
+    const [userGroupIds, adminBuildingIds] = await Promise.all([
+      prisma.userGroupMember.findMany({
         where: { userId: request.user.id },
         select: { groupId: true },
-      })
-    ).map((m) => m.groupId)
+      }).then((rows) => rows.map((m) => m.groupId)),
+      prisma.userResourceRole.findMany({
+        where: { userId: request.user.id, scopeType: 'BUILDING', role: 'BUILDING_ADMIN' },
+        select: { buildingId: true },
+      }).then((rows) => rows.flatMap((r) => r.buildingId ? [r.buildingId] : [])),
+    ])
 
     const buildings = await prisma.building.findMany({
       where: {
         OR: [
           { groupAccess: { none: {} } },                                    // open
           { groupAccess: { some: { groupId: { in: userGroupIds } } } },     // user's group has access
+          ...(adminBuildingIds.length > 0 ? [{ id: { in: adminBuildingIds } }] : []),  // user is building admin
         ],
       },
       include: {

--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -137,12 +137,18 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // POST /floors/:id/group-managers — assign a group as floor manager (SUPER_ADMIN only)
+  // POST /floors/:id/group-managers — assign a group as floor manager (SUPER_ADMIN or building admin)
   fastify.post(
     '/:id/group-managers',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id } = request.params as { id: string }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const floor = await prisma.floor.findUnique({ where: { id }, select: { buildingId: true } })
+        if (!floor) return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+        const canManage = await isBuildingManagerForBuilding(request.user.id, floor.buildingId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
       const bodyResult = z.object({ groupId: z.string().min(1) }).safeParse(request.body)
       if (!bodyResult.success) {
         return reply.status(400).send({ error: { message: 'groupId is required', code: 'VALIDATION_ERROR' } })
@@ -169,12 +175,18 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
-  // DELETE /floors/:id/group-managers/:groupId — remove a group floor manager (SUPER_ADMIN only)
+  // DELETE /floors/:id/group-managers/:groupId — remove a group floor manager (SUPER_ADMIN or building admin)
   fastify.delete(
     '/:id/group-managers/:groupId',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const { id, groupId } = request.params as { id: string; groupId: string }
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const floor = await prisma.floor.findUnique({ where: { id }, select: { buildingId: true } })
+        if (!floor) return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+        const canManage = await isBuildingManagerForBuilding(request.user.id, floor.buildingId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
+      }
 
       const role = await prisma.groupResourceRole.findFirst({
         where: { groupId, scopeType: 'FLOOR', floorId: id },
@@ -191,13 +203,18 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /floors — create floor
   fastify.post(
     '/',
-    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    { preHandler: [requireAuth] },
     async (request, reply) => {
       const result = createFloorSchema.safeParse(request.body)
       if (!result.success) {
         return reply.status(400).send({
           error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() },
         })
+      }
+
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        const canManage = await isBuildingManagerForBuilding(request.user.id, result.data.buildingId)
+        if (!canManage) return reply.status(403).send({ error: { message: 'Insufficient permissions', code: 'FORBIDDEN' } })
       }
 
       const building = await prisma.building.findUnique({ where: { id: result.data.buildingId } })


### PR DESCRIPTION
## Summary

Closes #73. Wires the existing `requireBuildingAdmin` / `isFloorManagerForFloor` / `isBuildingManagerForBuilding` helpers into every route that was previously locked to `SUPER_ADMIN` only.

**floors.ts**
- `POST /floors` — building admin can create a floor in their building
- `POST /floors/:id/group-managers` — building admin can assign group floor managers
- `DELETE /floors/:id/group-managers/:groupId` — building admin can remove group floor managers

**assets.ts**
- `POST /assets/bulk-import` — floor manager / building admin (scoped to their floors)
- `DELETE /assets/user-assignments/by-floor/:floorId` — floor manager / building admin
- `POST /assets/user-assignments/bulk` — floor manager / building admin (per-row floor check)
- `GET /assets/user-assignments/export` — building admin (scoped to managed buildings)
- `POST /assets` — floor manager / building admin when `floorId` is provided
- `DELETE /assets/:id` — floor manager / building admin for assets on managed floors
- `GET/POST/DELETE /assets/:id/user-assignments` — floor manager / building admin
- `PATCH /assets/:id/user-assignments/:userId/primary` — floor manager / building admin
- `GET /assets/:id/history` — floor manager / building admin
- `GET/POST/DELETE /assets/:id/allow-list` — floor manager / building admin
- `GET/POST/DELETE /assets/:id/zones` — floor manager / building admin

**analytics.ts**
- `GET /analytics/summary` — building admin sees stats scoped to managed buildings
- `GET /analytics/status-breakdown` — scoped to managed buildings
- `GET /analytics/peak-days` — scoped to managed buildings (building-filtered SQL join)

Routes intentionally kept SUPER_ADMIN only: asset categories (global), physical equipment assign/unassign.

## Test plan

- [ ] As a building admin, create a floor in your building → 201
- [ ] As a building admin, assign a group manager to a floor → 201
- [ ] As a building admin, bulk import assets to a floor → 200
- [ ] As a building admin, view `/analytics/summary` → 200, scoped data
- [ ] As a regular user, attempt any of the above → 403
- [ ] Build passes: `pnpm turbo build` ✅