### PR TITLE
fix: allow LDAP optional fields (syncBase) to be cleared via settings UI

### DIFF
--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -110,9 +110,9 @@ const ldapConfigSchema = z.object({
   tlsRejectUnauthorized: z.boolean().optional(),
   groupAttribute: z.string().optional(),
   groupMappings: z.array(groupMappingSchema).optional(),
-  // Directory sync settings
-  syncBase: z.string().optional(),
-  syncFilter: z.string().optional(),
+  // Directory sync settings — nullish so the UI can explicitly clear them
+  syncBase: z.string().nullish(),
+  syncFilter: z.string().nullish(),
   syncScope: z.enum(['sub', 'one']).optional(),
   deactivateMissing: z.boolean().optional(),
 })
@@ -379,9 +379,14 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
           })
         }
 
-        // Apply provided values; skip null/undefined secrets (means "keep existing")
+        // Apply provided values:
+        //   null   → explicitly clear the field (e.g. unsetting syncBase)
+        //   ''     → skip (secrets omit their value rather than send empty)
+        //   other  → set the value
         for (const [key, val] of Object.entries(body.config)) {
-          if (val !== null && val !== undefined && val !== '') {
+          if (val === null) {
+            delete mergedConfig[key]
+          } else if (val !== undefined && val !== '') {
             mergedConfig[key] = val
           }
         }

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -929,7 +929,9 @@ function LdapConfigForm({
       syncFilter, syncScope, deactivateMissing,
     }
     if (bindCredentials) cfg.bindCredentials = bindCredentials
-    if (syncBase.trim()) cfg.syncBase = syncBase.trim()
+    // Send null (not omit) when empty so the server knows to clear any previously stored value.
+    // This fixes the case where syncBase was set to an invalid DN and the user wants to reset it.
+    cfg.syncBase = syncBase.trim() || null
     onSave(cfg)
   }
 


### PR DESCRIPTION
## Problem

Once `syncBase` was saved to the database it could never be cleared through the settings UI:
- The UI only sent `syncBase` in the request when it was non-empty (omitted it otherwise)
- The server's config merge skipped `null`, `undefined`, and `''` values — all meaning "keep existing"

This meant a stale or invalid `syncBase` DN would permanently cause LDAP sync to fail with **"No Such Object"** (LDAP error 32) while login continued to work, because login uses `searchBase` directly whereas sync uses `syncBase || searchBase`.

## Fix

- **Server** (`settings.ts`): merge logic now treats explicit `null` as "delete this field" rather than "keep existing". Key-absent still means keep existing; `''` still skips (preserving secrets that omit their value).
- **Client** (`SettingsAdminPage.tsx`): LDAP `handleSave` now sends `syncBase: null` when the field is cleared, instead of omitting the key entirely.
- **Schema** (`settings.ts`): `syncBase` and `syncFilter` changed from `z.string().optional()` to `z.string().nullish()` to accept `null` in the request body.