### PR TITLE
chore: resolve merge conflict markers in SettingsAdminPage

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,12 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Existing tag to rebuild images for (e.g. v0.3.13)'
+        required: true
+        type: string
 
 jobs:
   # ── Release Please ────────────────────────────────────────────────────────────
@@ -16,12 +22,13 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      release_created: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.release_created }}
+      tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || steps.release.outputs.tag_name }}
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        if: github.event_name == 'push'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
@@ -38,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.sha }}
 
       - name: Docker metadata
         id: meta
@@ -84,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.sha }}
 
       - name: Docker metadata
         id: meta

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -941,14 +941,8 @@ function LdapConfigForm({
       syncFilter, syncScope, deactivateMissing,
     }
     if (bindCredentials) cfg.bindCredentials = bindCredentials
-<<<<<<< feat/department-support
-    if (syncBase.trim()) cfg.syncBase = syncBase.trim()
-    if (departmentAttribute.trim()) cfg.departmentAttribute = departmentAttribute.trim()
-=======
-    // Send null (not omit) when empty so the server knows to clear any previously stored value.
-    // This fixes the case where syncBase was set to an invalid DN and the user wants to reset it.
     cfg.syncBase = syncBase.trim() || null
->>>>>>> main
+    if (departmentAttribute.trim()) cfg.departmentAttribute = departmentAttribute.trim()
     onSave(cfg)
   }
 


### PR DESCRIPTION
## Summary

- Removes leftover merge conflict markers from `SettingsAdminPage.tsx` (line 944) that were causing a Vite parse error and blocking the ESLint CI check
- Preserves both changes from the conflicting sides: the `syncBase` null-clear fix (from main) and the `departmentAttribute` field (from feat/department-support)
- Adds `workflow_dispatch` to the Release Please workflow so Docker images can be manually rebuilt at any existing tag without bumping the version

## How to rebuild Docker images at the current version

After merging, run via CLI:
```bash
gh workflow run release-please.yml --field tag_name=v0.3.13
```
Or via GitHub UI: Actions → Release Please → Run workflow → enter the tag.