### PR TITLE
feat: webhook support (#82)

### DIFF
--- a/apps/api/prisma/migrations/20260506000000_add_webhooks/migration.sql
+++ b/apps/api/prisma/migrations/20260506000000_add_webhooks/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "WebhookEndpoint" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "events" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WebhookEndpoint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "endpointId" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "statusCode" INTEGER,
+    "success" BOOLEAN NOT NULL,
+    "error" TEXT,
+    "attempt" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookEndpoint_enabled_idx" ON "WebhookEndpoint"("enabled");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_endpointId_createdAt_idx" ON "WebhookDelivery"("endpointId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_event_idx" ON "WebhookDelivery"("event");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_success_idx" ON "WebhookDelivery"("success");
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_endpointId_fkey" FOREIGN KEY ("endpointId") REFERENCES "WebhookEndpoint"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -690,3 +690,37 @@ model Session {
   @@index([expire], name: "IDX_session_expire")
   @@map("sessions")
 }
+
+/// Outbound webhook endpoint registered by an admin.
+/// The secret is used to sign every delivery with HMAC-SHA256 (X-Roomer-Signature header).
+/// Events is an array of event-type strings — e.g. ["booking.created", "asset.updated"].
+model WebhookEndpoint {
+  id         String            @id @default(cuid())
+  url        String
+  secret     String
+  events     String[]
+  enabled    Boolean           @default(true)
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
+  deliveries WebhookDelivery[]
+
+  @@index([enabled])
+}
+
+/// Log of each attempt to deliver a webhook payload to an endpoint.
+model WebhookDelivery {
+  id         String          @id @default(cuid())
+  endpointId String
+  endpoint   WebhookEndpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade)
+  event      String
+  payload    Json
+  statusCode Int?
+  success    Boolean
+  error      String?
+  attempt    Int             @default(1)
+  createdAt  DateTime        @default(now())
+
+  @@index([endpointId, createdAt])
+  @@index([event])
+  @@index([success])
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -27,6 +27,7 @@ import { scimRoutes } from './routes/scim.js'
 import { departmentRoutes } from './routes/departments.js'
 import { subscriptionRoutes } from './routes/subscriptions.js'
 import { recurringBookingRoutes } from './routes/recurring.js'
+import { webhookRoutes } from './routes/webhooks.js'
 import { getBoss } from './lib/queue.js'
 import { prisma } from './lib/prisma.js'
 import { register, httpRequestDuration, setupMetrics } from './lib/metrics.js'
@@ -118,6 +119,7 @@ export async function buildApp(): Promise<FastifyInstance> {
           { name: 'Subscriptions', description: 'Floor availability subscriptions and notifications' },
           { name: 'Recurring Bookings', description: 'Weekly recurring booking rules and series management' },
           { name: 'Departments', description: 'Department hierarchy and user membership (admin only)' },
+          { name: 'Webhooks', description: 'Webhook endpoint management and delivery log (super admin only)' },
         ],
         components: {
           securitySchemes: {
@@ -232,6 +234,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(recurringBookingRoutes, { prefix: '/api/v1/recurring-bookings' })
   await fastify.register(scimRoutes, { prefix: '/scim/v2' })
   await fastify.register(departmentRoutes, { prefix: '/api/v1/departments' })
+  await fastify.register(webhookRoutes, { prefix: '/api/v1/webhooks' })
 
   // ─── Health checks ─────────────────────────────────────────────────────────
   // /health/live — process is running (Kubernetes liveness probe)

--- a/apps/api/src/lib/ldap.ts
+++ b/apps/api/src/lib/ldap.ts
@@ -1,6 +1,7 @@
 import ldap from 'ldapjs'
 import { prisma, findAuthConfig } from './prisma.js'
 import type { GroupMapping } from './group-mapping.js'
+import { dispatchWebhook } from './webhook.js'
 
 export interface LdapConfig {
   url: string
@@ -183,6 +184,10 @@ export async function syncLdapUsers(cfg: LdapConfig): Promise<LdapSyncResult> {
     }
   } finally {
     unbind(client)
+  }
+
+  if (result.created > 0 || result.updated > 0) {
+    dispatchWebhook('user.imported', { created: result.created, updated: result.updated, deactivated: result.deactivated }).catch(() => {})
   }
 
   return result

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -5,6 +5,7 @@ import { sendEmail, renderBookingConfirmed, renderBookingCancelled, renderBookin
 import { randomUUID } from 'crypto'
 import { pruneExpiredBlocklistEntries } from './token-blocklist.js'
 import { NotificationType } from '@roomer/shared'
+import { dispatchWebhook } from './webhook.js'
 
 let boss: PgBoss | null = null
 
@@ -304,13 +305,22 @@ async function handleExpireQueueEntries(): Promise<void> {
 // ─── Worker: auto-complete-bookings (cron every 30 min) ──────────────────────
 
 async function handleAutoCompleteBookings(): Promise<void> {
-  const result = await prisma.booking.updateMany({
+  const bookings = await prisma.booking.findMany({
     where: { status: 'CONFIRMED', endsAt: { lt: new Date() } },
+    select: { id: true, userId: true, assetId: true, startsAt: true, endsAt: true },
+  })
+  if (bookings.length === 0) return
+
+  await prisma.booking.updateMany({
+    where: { id: { in: bookings.map((b) => b.id) } },
     data: { status: 'COMPLETED' },
   })
-  if (result.count > 0) {
-    process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Auto-completed past bookings', count: result.count }) + '\n')
+
+  for (const booking of bookings) {
+    dispatchWebhook('booking.completed', booking).catch(() => {})
   }
+
+  process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Auto-completed past bookings', count: bookings.length }) + '\n')
 }
 
 // ─── Worker: expire-claim-deadlines (cron every 5 min) ───────────────────────
@@ -333,6 +343,10 @@ async function handleExpireClaimDeadlines(): Promise<void> {
     where: { id: { in: expiredPromoted.map((e) => e.id) } },
     data: { status: 'EXPIRED' },
   })
+
+  for (const entry of expiredPromoted) {
+    dispatchWebhook('queue.expired', { id: entry.id, userId: entry.userId, assetId: entry.assetId }).catch(() => {})
+  }
 
   // Find the next WAITING entry for each expired slot in parallel
   const claimDeadline = new Date(Date.now() + CLAIM_DEADLINE_MS)
@@ -373,6 +387,10 @@ async function handleExpireClaimDeadlines(): Promise<void> {
         } satisfies NotificationJobData,
       })),
     )
+
+    for (const nextEntry of toPromote) {
+      dispatchWebhook('queue.promoted', { id: nextEntry.id, userId: nextEntry.userId, assetId: nextEntry.assetId, claimDeadline: claimDeadline.toISOString() }).catch(() => {})
+    }
   }
 
   process.stdout.write(JSON.stringify({ level: 'info', msg: '[queue] Processed expired claim deadlines', count: expiredPromoted.length }) + '\n')
@@ -433,8 +451,12 @@ export async function startQueue(): Promise<void> {
   await b.createQueue('prune-revoked-tokens')
   await b.createQueue('auto-complete-bookings')
   await b.createQueue('send-booking-reminders')
+  await b.createQueue('webhook-delivery')
 
   await b.work<NotificationJobData>('send-notification', handleSendNotification)
+
+  const { deliverWebhookJob } = await import('./webhook.js')
+  await b.work('webhook-delivery', deliverWebhookJob)
 
   await b.work('expire-queue-entries', async () => {
     await handleExpireQueueEntries()

--- a/apps/api/src/lib/webhook.ts
+++ b/apps/api/src/lib/webhook.ts
@@ -40,6 +40,76 @@ function sign(secret: string, body: string): string {
   return `sha256=${crypto.createHmac('sha256', secret).update(body).digest('hex')}`
 }
 
+const assetInclude = {
+  category: { select: { name: true } },
+  primaryZone: { select: { name: true } },
+  floor: { select: { name: true, building: { select: { name: true } } } },
+} as const
+
+async function enrichPayload(event: WebhookEvent, data: unknown): Promise<unknown> {
+  const d = data as Record<string, unknown>
+
+  if (event.startsWith('booking.')) {
+    const booking = await prisma.booking.findUnique({
+      where: { id: d.id as string },
+      select: {
+        user: { select: { id: true, email: true, displayName: true } },
+        asset: { select: { id: true, name: true, ...assetInclude } },
+      },
+    }).catch(() => null)
+    return {
+      ...d,
+      ...(booking?.user && { user: booking.user }),
+      ...(booking?.asset && { asset: booking.asset }),
+    }
+  }
+
+  if (event.startsWith('queue.')) {
+    const entry = await prisma.queueEntry.findUnique({
+      where: { id: d.id as string },
+      select: {
+        user: { select: { id: true, email: true, displayName: true } },
+        asset: { select: { id: true, name: true, ...assetInclude } },
+      },
+    }).catch(() => null)
+    return {
+      ...d,
+      ...(entry?.user && { user: entry.user }),
+      ...(entry?.asset && { asset: entry.asset }),
+    }
+  }
+
+  if (event === 'asset.created' || event === 'asset.updated' || event === 'asset.status_changed') {
+    const asset = await prisma.asset.findUnique({
+      where: { id: d.id as string },
+      select: { name: true, ...assetInclude },
+    }).catch(() => null)
+    return { ...d, ...(asset && { asset }) }
+  }
+
+  if (event === 'asset_assignment.created' || event === 'asset_assignment.returned') {
+    const [asset, user] = await Promise.all([
+      prisma.asset.findUnique({ where: { id: d.assetId as string }, select: { name: true, ...assetInclude } }).catch(() => null),
+      prisma.user.findUnique({ where: { id: d.userId as string }, select: { id: true, email: true, displayName: true } }).catch(() => null),
+    ])
+    return {
+      ...d,
+      ...(asset && { asset: { id: d.assetId, ...asset } }),
+      ...(user && { user }),
+    }
+  }
+
+  if (event === 'user.created' || event === 'user.updated' || event === 'user.suspended') {
+    const user = await prisma.user.findUnique({
+      where: { id: d.id as string },
+      select: { id: true, email: true, displayName: true, globalRole: true, accountStatus: true, departmentId: true },
+    }).catch(() => null)
+    return { ...d, ...(user && { user }) }
+  }
+
+  return data
+}
+
 /** Enqueue a webhook delivery job for every enabled endpoint subscribed to the event. */
 export async function dispatchWebhook(event: WebhookEvent, data: unknown): Promise<void> {
   const endpoints = await prisma.webhookEndpoint.findMany({
@@ -49,7 +119,8 @@ export async function dispatchWebhook(event: WebhookEvent, data: unknown): Promi
   if (endpoints.length === 0) return
 
   const timestamp = new Date().toISOString()
-  const payload = JSON.stringify({ event, timestamp, data })
+  const enriched = await enrichPayload(event, data)
+  const payload = JSON.stringify({ event, timestamp, data: enriched })
 
   const boss = getBoss()
   await boss.insert(

--- a/apps/api/src/lib/webhook.ts
+++ b/apps/api/src/lib/webhook.ts
@@ -1,0 +1,124 @@
+import crypto from 'crypto'
+import { randomUUID } from 'crypto'
+import { prisma } from './prisma.js'
+import { getBoss } from './queue.js'
+import type { Job } from 'pg-boss'
+
+export const WEBHOOK_EVENTS = [
+  'booking.created',
+  'booking.modified',
+  'booking.cancelled',
+  'booking.completed',
+  'queue.joined',
+  'queue.promoted',
+  'queue.claimed',
+  'queue.expired',
+  'queue.cancelled',
+  'asset.created',
+  'asset.updated',
+  'asset.status_changed',
+  'asset_assignment.created',
+  'asset_assignment.returned',
+  'user.created',
+  'user.updated',
+  'user.suspended',
+  'user.imported',
+] as const
+
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number]
+
+export interface WebhookDeliveryJobData {
+  endpointId: string
+  deliveryId: string
+  url: string
+  secret: string
+  event: WebhookEvent
+  payload: string // pre-serialised JSON
+}
+
+function sign(secret: string, body: string): string {
+  return `sha256=${crypto.createHmac('sha256', secret).update(body).digest('hex')}`
+}
+
+/** Enqueue a webhook delivery job for every enabled endpoint subscribed to the event. */
+export async function dispatchWebhook(event: WebhookEvent, data: unknown): Promise<void> {
+  const endpoints = await prisma.webhookEndpoint.findMany({
+    where: { enabled: true, events: { has: event } },
+    select: { id: true, url: true, secret: true },
+  })
+  if (endpoints.length === 0) return
+
+  const timestamp = new Date().toISOString()
+  const payload = JSON.stringify({ event, timestamp, data })
+
+  const boss = getBoss()
+  await boss.insert(
+    'webhook-delivery',
+    endpoints.map((ep) => {
+      const deliveryId = randomUUID()
+      return {
+        data: {
+          endpointId: ep.id,
+          deliveryId,
+          url: ep.url,
+          secret: ep.secret,
+          event,
+          payload,
+        } satisfies WebhookDeliveryJobData,
+        retryLimit: 5,
+        retryDelay: 60,
+        retryBackoff: true,
+        expireInSeconds: 86400,
+      }
+    }),
+  )
+}
+
+/** pg-boss worker handler — called for each batch of webhook-delivery jobs. */
+export async function deliverWebhookJob(jobs: Job<WebhookDeliveryJobData>[]): Promise<void> {
+  for (const job of jobs) {
+    await deliverOne(job.data)
+  }
+}
+
+async function deliverOne({ endpointId, deliveryId, url, secret, event, payload }: WebhookDeliveryJobData): Promise<void> {
+  const signature = sign(secret, payload)
+
+  let statusCode: number | null = null
+  let success = false
+  let error: string | null = null
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Roomer-Event': event,
+        'X-Roomer-Delivery': deliveryId,
+        'X-Roomer-Signature': signature,
+      },
+      body: payload,
+      signal: AbortSignal.timeout(10_000),
+    })
+    statusCode = res.status
+    success = res.ok
+    if (!res.ok) error = `HTTP ${res.status}`
+  } catch (err) {
+    error = err instanceof Error ? err.message : 'Unknown error'
+  }
+
+  await prisma.webhookDelivery.create({
+    data: {
+      id: deliveryId,
+      endpointId,
+      event,
+      payload: JSON.parse(payload),
+      statusCode,
+      success,
+      error,
+      attempt: 1,
+    },
+  })
+
+  if (!success) throw new Error(error ?? 'Delivery failed')
+}

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -5,6 +5,7 @@ import { GlobalRole, BookableStatus, bulkUpdateAssetPositionsSchema, Notificatio
 import { requireAuth } from '../middleware/requireAuth.js'
 import { requireGlobalRole, getManagedFloorIds, getManagedBuildingIds, isFloorManagerForFloor } from '../middleware/requireRole.js'
 import { enqueueNotification, fanOutFloorAvailable } from '../lib/queue.js'
+import { dispatchWebhook } from '../lib/webhook.js'
 import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import { checkGroupAccess } from './groups.js'
@@ -861,6 +862,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
           },
           include: { category: true },
         })
+        dispatchWebhook('asset.created', { id: asset.id, name: asset.name, categoryId: asset.categoryId }).catch(() => {})
         return reply.status(201).send({ data: asset })
       } catch {
         return reply.status(409).send({
@@ -911,6 +913,12 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
           },
           include: { category: true },
         })
+        const statusChanged = result.data.status !== undefined || result.data.bookingStatus !== undefined
+        if (statusChanged) {
+          dispatchWebhook('asset.status_changed', { id: asset.id, name: asset.name, status: asset.status, bookingStatus: asset.bookingStatus }).catch(() => {})
+        } else {
+          dispatchWebhook('asset.updated', { id: asset.id, name: asset.name }).catch(() => {})
+        }
         return reply.status(200).send({ data: asset })
       } catch (err) {
         if ((err as { code?: string }).code === 'P2025') {
@@ -992,6 +1000,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
         prisma.asset.update({ where: { id }, data: { status: 'ASSIGNED' } }),
       ])
 
+      dispatchWebhook('asset_assignment.created', { assetId: id, userId, assignedById: request.user.id }).catch(() => {})
       return reply.status(201).send({ data: assignment })
     },
   )
@@ -1031,6 +1040,7 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
         prisma.asset.update({ where: { id }, data: { status: 'AVAILABLE' } }),
       ])
 
+      dispatchWebhook('asset_assignment.returned', { assetId: id, userId: activeAssignment.userId, returnedAt: assignment.returnedAt }).catch(() => {})
       return reply.status(200).send({ data: assignment })
     },
   )

--- a/apps/api/src/routes/bookings.ts
+++ b/apps/api/src/routes/bookings.ts
@@ -5,6 +5,7 @@ import { createBookingSchema, updateBookingSchema, GlobalRole, NotificationType 
 import { requireAuth } from '../middleware/requireAuth.js'
 import { isFloorManagerForFloor, getManagedBuildingIds } from '../middleware/requireRole.js'
 import { enqueueNotification, fanOutFloorAvailable, CLAIM_DEADLINE_MS } from '../lib/queue.js'
+import { dispatchWebhook } from '../lib/webhook.js'
 import { randomUUID } from 'crypto'
 import { checkGroupAccess } from './groups.js'
 import { z } from 'zod'
@@ -317,6 +318,8 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
       bookingId: booking.id,
     })
 
+    dispatchWebhook('booking.created', { id: booking.id, userId: booking.userId, assetId: booking.assetId, startsAt: booking.startsAt, endsAt: booking.endsAt }).catch(() => {})
+
     return reply.status(201).send({ data: booking })
   })
 
@@ -411,6 +414,8 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
       throw err
     }
 
+    dispatchWebhook('booking.modified', { id: updated.id, userId: updated.userId, assetId: updated.assetId, startsAt: updated.startsAt, endsAt: updated.endsAt }).catch(() => {})
+
     return reply.status(200).send({ data: updated })
   })
 
@@ -442,6 +447,8 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
 
     // Cancel the booking
     await prisma.booking.update({ where: { id }, data: { status: 'CANCELLED' } })
+
+    dispatchWebhook('booking.cancelled', { id: booking.id, userId: booking.userId, assetId: booking.assetId }).catch(() => {})
 
     // Notify the original booker
     const notificationType = !isSelf

--- a/apps/api/src/routes/queue.ts
+++ b/apps/api/src/routes/queue.ts
@@ -3,6 +3,7 @@ import { prisma } from '../lib/prisma.js'
 import { createQueueEntrySchema, NotificationType, GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { enqueueNotification } from '../lib/queue.js'
+import { dispatchWebhook } from '../lib/webhook.js'
 import { checkGroupAccess } from './groups.js'
 import { z } from 'zod'
 
@@ -130,6 +131,8 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
       queueEntryId: entry.id,
     })
 
+    dispatchWebhook('queue.joined', { id: entry.id, userId: entry.userId, assetId: entry.assetId, position: entry.position }).catch(() => {})
+
     return reply.status(201).send({ data: entry })
   })
 
@@ -156,6 +159,8 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
       where: { id },
       data: { status: 'CANCELLED' },
     })
+
+    dispatchWebhook('queue.cancelled', { id: entry.id, userId: entry.userId, assetId: entry.assetId }).catch(() => {})
 
     // Compact positions: decrement all WAITING entries for the same asset/period that were behind the cancelled one
     await prisma.queueEntry.updateMany({
@@ -237,6 +242,8 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
       bookingId: result.id,
     })
 
+    dispatchWebhook('queue.claimed', { id: entry.id, userId: entry.userId, assetId: entry.assetId, bookingId: result.id }).catch(() => {})
+
     return reply.status(201).send({ data: { booking: result, queueEntry: { id: entry.id, status: 'CLAIMED' } } })
   })
 
@@ -310,6 +317,8 @@ export async function queueRoutes(fastify: FastifyInstance): Promise<void> {
       userId: request.user.id,
       bookingId: booking.id,
     })
+
+    dispatchWebhook('queue.claimed', { id: entry.id, userId: entry.userId, assetId: entry.assetId, bookingId: booking.id }).catch(() => {})
 
     return reply.status(201).send({ data: { booking, queueEntry: { id, status: 'CLAIMED' } } })
   })

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -6,6 +6,7 @@ import { GlobalRole, ResourceRoleType, ResourceScopeType } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { requireGlobalRole } from '../middleware/requireRole.js'
 import { enqueueNotification } from '../lib/queue.js'
+import { dispatchWebhook } from '../lib/webhook.js'
 import { NotificationType } from '@roomer/shared'
 import { z } from 'zod'
 
@@ -116,6 +117,8 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
       enqueueNotification({ type: NotificationType.WELCOME, userId: user.id }).catch((err) =>
         fastify.log.warn({ err }, 'Failed to enqueue welcome notification'),
       )
+
+      dispatchWebhook('user.created', { id: user.id, email: user.email, displayName: user.displayName, globalRole: user.globalRole }).catch(() => {})
 
       return reply.status(201).send({ data: user })
     },
@@ -254,6 +257,13 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
           updatedAt: true,
         },
       })
+
+      if (result.data.accountStatus === 'BLOCKED') {
+        dispatchWebhook('user.suspended', { id: updated.id, email: updated.email }).catch(() => {})
+      } else {
+        dispatchWebhook('user.updated', { id: updated.id, email: updated.email, displayName: updated.displayName }).catch(() => {})
+      }
+
       return reply.status(200).send({ data: updated })
     } catch {
       return reply.status(404).send({ error: { message: 'User not found', code: 'NOT_FOUND' } })

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,134 @@
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { randomBytes } from 'crypto'
+import { prisma } from '../lib/prisma.js'
+import { requireAuth } from '../middleware/requireAuth.js'
+import { requireGlobalRole } from '../middleware/requireRole.js'
+import { GlobalRole } from '@roomer/shared'
+import { WEBHOOK_EVENTS } from '../lib/webhook.js'
+
+const createEndpointSchema = z.object({
+  url: z.string().url(),
+  events: z.array(z.enum(WEBHOOK_EVENTS)).min(1),
+  secret: z.string().min(16).optional(),
+  enabled: z.boolean().optional(),
+})
+
+const updateEndpointSchema = z.object({
+  url: z.string().url().optional(),
+  events: z.array(z.enum(WEBHOOK_EVENTS)).min(1).optional(),
+  secret: z.string().min(16).optional(),
+  enabled: z.boolean().optional(),
+})
+
+export async function webhookRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Webhooks'], ...route.schema } })
+
+  const adminGuard = [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)]
+
+  // GET /webhooks/events — list all supported event types
+  fastify.get('/events', { preHandler: [requireAuth] }, async (_req, reply) => {
+    return reply.send({ data: WEBHOOK_EVENTS })
+  })
+
+  // GET /webhooks — list all endpoints
+  fastify.get('/', { preHandler: adminGuard }, async (_req, reply) => {
+    const endpoints = await prisma.webhookEndpoint.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, url: true, events: true, enabled: true, createdAt: true, updatedAt: true },
+    })
+    return reply.send({ data: endpoints })
+  })
+
+  // POST /webhooks — create endpoint
+  fastify.post('/', { preHandler: adminGuard }, async (request, reply) => {
+    const result = createEndpointSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() } })
+    }
+    const secret = result.data.secret ?? randomBytes(32).toString('hex')
+    const endpoint = await prisma.webhookEndpoint.create({
+      data: {
+        url: result.data.url,
+        secret,
+        events: result.data.events,
+        enabled: result.data.enabled ?? true,
+      },
+    })
+    return reply.status(201).send({ data: { ...endpoint } })
+  })
+
+  // PATCH /webhooks/:id — update endpoint
+  fastify.patch('/:id', { preHandler: adminGuard }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const result = updateEndpointSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() } })
+    }
+    const existing = await prisma.webhookEndpoint.findUnique({ where: { id } })
+    if (!existing) return reply.status(404).send({ error: { message: 'Webhook endpoint not found', code: 'NOT_FOUND' } })
+
+    const endpoint = await prisma.webhookEndpoint.update({
+      where: { id },
+      data: result.data,
+      select: { id: true, url: true, events: true, enabled: true, createdAt: true, updatedAt: true },
+    })
+    return reply.send({ data: endpoint })
+  })
+
+  // DELETE /webhooks/:id — delete endpoint
+  fastify.delete('/:id', { preHandler: adminGuard }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const existing = await prisma.webhookEndpoint.findUnique({ where: { id } })
+    if (!existing) return reply.status(404).send({ error: { message: 'Webhook endpoint not found', code: 'NOT_FOUND' } })
+    await prisma.webhookEndpoint.delete({ where: { id } })
+    return reply.send({ data: { ok: true } })
+  })
+
+  // POST /webhooks/:id/ping — send a test ping to an endpoint
+  fastify.post('/:id/ping', { preHandler: adminGuard }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const existing = await prisma.webhookEndpoint.findUnique({ where: { id } })
+    if (!existing) return reply.status(404).send({ error: { message: 'Webhook endpoint not found', code: 'NOT_FOUND' } })
+    const { dispatchWebhook } = await import('../lib/webhook.js')
+    // Temporarily use the endpoint directly regardless of enabled state
+    const { prisma: db } = await import('../lib/prisma.js')
+    // Re-enable temporarily if disabled so dispatchWebhook finds it
+    const wasDisabled = !existing.enabled
+    if (wasDisabled) await db.webhookEndpoint.update({ where: { id }, data: { enabled: true } })
+    try {
+      await dispatchWebhook('booking.created', { ping: true, endpointId: id })
+    } finally {
+      if (wasDisabled) await db.webhookEndpoint.update({ where: { id }, data: { enabled: false } })
+    }
+    return reply.send({ data: { ok: true } })
+  })
+
+  // GET /webhooks/:id/deliveries — delivery log for an endpoint
+  fastify.get('/:id/deliveries', { preHandler: adminGuard }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { page = '1', limit = '50' } = request.query as Record<string, string>
+    const pageNum = Math.max(1, parseInt(page, 10) || 1)
+    const limitNum = Math.min(100, Math.max(1, parseInt(limit, 10) || 50))
+    const skip = (pageNum - 1) * limitNum
+
+    const existing = await prisma.webhookEndpoint.findUnique({ where: { id } })
+    if (!existing) return reply.status(404).send({ error: { message: 'Webhook endpoint not found', code: 'NOT_FOUND' } })
+
+    const [deliveries, total] = await Promise.all([
+      prisma.webhookDelivery.findMany({
+        where: { endpointId: id },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limitNum,
+        select: { id: true, event: true, statusCode: true, success: true, error: true, attempt: true, createdAt: true },
+      }),
+      prisma.webhookDelivery.count({ where: { endpointId: id } }),
+    ])
+
+    return reply.send({
+      data: deliveries,
+      meta: { total, page: pageNum, limit: limitNum, totalPages: Math.ceil(total / limitNum) },
+    })
+  })
+}

--- a/apps/web/src/hooks/useNavConfig.ts
+++ b/apps/web/src/hooks/useNavConfig.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useAuthStore } from '@/stores/auth'
 import { useQuery } from '@tanstack/react-query'
 import { buildingsApi } from '@/lib/api'
-import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers, Network } from 'lucide-react'
+import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers, Network, Webhook } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavItem {
@@ -89,6 +89,7 @@ export function useNavConfig() {
           { to: '/admin/leases', icon: FileText, label: 'Leases' },
           { to: '/admin/groups', icon: Shield, label: 'Access Groups' },
           { to: '/admin/reports', icon: BarChart3, label: 'Reports' },
+          { to: '/admin/webhooks', icon: Webhook, label: 'Webhooks' },
           { to: '/admin/settings', icon: Settings, label: 'Settings' },
         ],
       })

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -696,6 +696,41 @@ export const recurringBookingsApi = {
   cancel: (id: string) => api.delete<{ data: { ok: true } }>(`/recurring-bookings/${id}`),
 }
 
+// --- Webhooks ---
+export interface WebhookEndpoint {
+  id: string
+  url: string
+  events: string[]
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WebhookDelivery {
+  id: string
+  event: string
+  statusCode: number | null
+  success: boolean
+  error: string | null
+  attempt: number
+  createdAt: string
+}
+
+export const webhooksApi = {
+  listEvents: () => api.get<{ data: string[] }>('/webhooks/events'),
+  list: () => api.get<{ data: WebhookEndpoint[] }>('/webhooks'),
+  create: (body: { url: string; events: string[]; secret?: string; enabled?: boolean }) =>
+    api.post<{ data: WebhookEndpoint & { secret: string } }>('/webhooks', body),
+  update: (id: string, body: { url?: string; events?: string[]; secret?: string; enabled?: boolean }) =>
+    api.patch<{ data: WebhookEndpoint }>(`/webhooks/${id}`, body),
+  delete: (id: string) => api.delete<{ data: { ok: true } }>(`/webhooks/${id}`),
+  ping: (id: string) => api.post<{ data: { ok: true } }>(`/webhooks/${id}/ping`),
+  deliveries: (id: string, page = 1, limit = 50) =>
+    api.get<{ data: WebhookDelivery[]; meta: { total: number; page: number; limit: number; totalPages: number } }>(
+      `/webhooks/${id}/deliveries?page=${page}&limit=${limit}`,
+    ),
+}
+
 // --- Departments ---
 export interface Department {
   id: string

--- a/apps/web/src/pages/admin/WebhooksAdminPage.tsx
+++ b/apps/web/src/pages/admin/WebhooksAdminPage.tsx
@@ -279,15 +279,19 @@ export default function WebhooksAdminPage() {
   })
 
   return (
-    <div className="p-6 space-y-4">
-      <div className="flex items-center justify-end">
-        <Button onClick={() => setShowCreate(true)}>
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Webhooks</h1>
+          <p className="text-muted-foreground text-sm mt-1">Manage webhook endpoints and delivery history</p>
+        </div>
+        <Button onClick={() => setShowCreate(true)} size="sm">
           <Plus className="h-4 w-4 mr-2" />
           Add endpoint
         </Button>
       </div>
 
-      <Card>
+      <Card className="mb-6">
         <CardContent className="p-0">
           {isLoading ? (
             <div className="p-4 space-y-3">

--- a/apps/web/src/pages/admin/WebhooksAdminPage.tsx
+++ b/apps/web/src/pages/admin/WebhooksAdminPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Plus, Trash2, Send, Eye, CheckCircle2, XCircle, Pencil } from 'lucide-react'
+import { Plus, Trash2, Send, Eye, CheckCircle2, XCircle, Pencil, Copy, Check } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { webhooksApi, type WebhookEndpoint, type WebhookDelivery } from '@/lib/api'
 import { toast } from 'sonner'
@@ -69,6 +69,8 @@ function EndpointDialog({
   const [selectedEvents, setSelectedEvents] = useState<Set<string>>(
     new Set(endpoint?.events ?? []),
   )
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
 
   function toggleEvent(event: string) {
     setSelectedEvents((prev) => {
@@ -89,6 +91,14 @@ function EndpointDialog({
     })
   }
 
+  function copySecret() {
+    if (!revealedSecret) return
+    navigator.clipboard.writeText(revealedSecret).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
   const save = useMutation({
     mutationFn: () => {
       const body = { url, events: [...selectedEvents], ...(secret ? { secret } : {}), enabled }
@@ -97,14 +107,14 @@ function EndpointDialog({
         : webhooksApi.create(body)
     },
     onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['webhooks'] })
       if (!isEdit) {
         const created = (data as { data: WebhookEndpoint & { secret: string } }).data
-        toast.success(`Endpoint created. Secret: ${created.secret}`, { duration: 15000, description: 'Copy this secret now — it will not be shown again.' })
+        setRevealedSecret(created.secret)
       } else {
         toast.success('Endpoint updated')
+        onClose()
       }
-      qc.invalidateQueries({ queryKey: ['webhooks'] })
-      onClose()
     },
     onError: () => toast.error(isEdit ? 'Failed to update endpoint' : 'Failed to create endpoint'),
   })
@@ -116,6 +126,37 @@ function EndpointDialog({
   }, {})
 
   const canSave = url.trim().length > 0 && selectedEvents.size > 0
+
+  if (revealedSecret) {
+    return (
+      <Dialog open={open} onOpenChange={() => {}}>
+        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
+          <DialogHeader>
+            <DialogTitle>Save your webhook secret</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-1">
+            <p className="text-sm text-muted-foreground">
+              This secret will <span className="font-semibold text-foreground">not be shown again</span>. Copy it now and store it somewhere safe — you'll need it to verify webhook signatures.
+            </p>
+            <div className="flex gap-2">
+              <Input
+                readOnly
+                value={revealedSecret}
+                className="font-mono text-sm"
+                onFocus={(e) => e.target.select()}
+              />
+              <Button size="icon" variant="outline" onClick={copySecret} title="Copy secret">
+                {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={onClose}>I've saved my secret</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  }
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>

--- a/apps/web/src/pages/admin/WebhooksAdminPage.tsx
+++ b/apps/web/src/pages/admin/WebhooksAdminPage.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
-import { Webhook, Plus, Trash2, Send, Eye, CheckCircle2, XCircle, Pencil } from 'lucide-react'
+import { Plus, Trash2, Send, Eye, CheckCircle2, XCircle, Pencil } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { webhooksApi, type WebhookEndpoint, type WebhookDelivery } from '@/lib/api'
 import { toast } from 'sonner'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -22,6 +22,31 @@ import {
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
+
+// ─── Toggle (matches ProfilePage notification preference style) ───────────────
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`
+        relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full
+        transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+        ${checked ? 'bg-primary' : 'bg-input'}
+      `}
+    >
+      <span
+        className={`
+          pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform
+          ${checked ? 'translate-x-4' : 'translate-x-0.5'}
+        `}
+      />
+    </button>
+  )
+}
 
 // ─── Endpoint form dialog ─────────────────────────────────────────────────────
 
@@ -107,30 +132,27 @@ function EndpointDialog({
             <Label htmlFor="ep-secret">{isEdit ? 'New secret (leave blank to keep existing)' : 'Secret (optional — auto-generated if blank)'}</Label>
             <Input id="ep-secret" className="mt-1.5" type="password" placeholder={isEdit ? 'Leave blank to keep existing' : 'Auto-generated'} value={secret} onChange={(e) => setSecret(e.target.value)} />
           </div>
-          <div className="flex items-center gap-2">
-            <input type="checkbox" id="ep-enabled" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} className="h-4 w-4 rounded border-border" />
-            <Label htmlFor="ep-enabled">Enabled</Label>
+          <div className="flex items-center gap-3">
+            <Toggle checked={enabled} onChange={setEnabled} />
+            <Label htmlFor="ep-enabled" className="cursor-pointer" onClick={() => setEnabled((v) => !v)}>Enabled</Label>
           </div>
           <div>
             <Label>Events *</Label>
             <div className="mt-2 space-y-3 rounded-md border p-3 max-h-64 overflow-y-auto">
               {Object.entries(grouped).map(([prefix, events]) => (
                 <div key={prefix}>
-                  <div className="flex items-center gap-2 mb-1">
-                    <input
-                      type="checkbox"
-                      id={`group-${prefix}`}
+                  <div className="flex items-center gap-3 mb-2">
+                    <Toggle
                       checked={events.every((e) => selectedEvents.has(e))}
                       onChange={() => toggleGroup(events)}
-                      className="h-4 w-4 rounded border-border"
                     />
-                    <label htmlFor={`group-${prefix}`} className="text-sm font-medium capitalize cursor-pointer">{prefix}</label>
+                    <span className="text-sm font-medium capitalize">{prefix}</span>
                   </div>
-                  <div className="ml-6 space-y-1">
+                  <div className="ml-12 space-y-2">
                     {events.map((e) => (
-                      <div key={e} className="flex items-center gap-2">
-                        <input type="checkbox" id={`ev-${e}`} checked={selectedEvents.has(e)} onChange={() => toggleEvent(e)} className="h-4 w-4 rounded border-border" />
-                        <label htmlFor={`ev-${e}`} className="text-xs font-mono cursor-pointer">{e}</label>
+                      <div key={e} className="flex items-center gap-3">
+                        <Toggle checked={selectedEvents.has(e)} onChange={() => toggleEvent(e)} />
+                        <span className="text-xs font-mono">{e}</span>
                       </div>
                     ))}
                   </div>
@@ -257,12 +279,8 @@ export default function WebhooksAdminPage() {
   })
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Webhook className="h-6 w-6 text-primary" />
-          <h1 className="text-2xl font-bold">Webhooks</h1>
-        </div>
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-end">
         <Button onClick={() => setShowCreate(true)}>
           <Plus className="h-4 w-4 mr-2" />
           Add endpoint
@@ -270,9 +288,6 @@ export default function WebhooksAdminPage() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>Endpoints</CardTitle>
-        </CardHeader>
         <CardContent className="p-0">
           {isLoading ? (
             <div className="p-4 space-y-3">
@@ -305,11 +320,9 @@ export default function WebhooksAdminPage() {
                       </div>
                     </TableCell>
                     <TableCell>
-                      <input
-                        type="checkbox"
+                      <Toggle
                         checked={ep.enabled}
-                        onChange={(e) => toggleEnabled.mutate({ id: ep.id, enabled: e.target.checked })}
-                        className="h-4 w-4 rounded border-border"
+                        onChange={(v) => toggleEnabled.mutate({ id: ep.id, enabled: v })}
                       />
                     </TableCell>
                     <TableCell className="text-right">

--- a/apps/web/src/pages/admin/WebhooksAdminPage.tsx
+++ b/apps/web/src/pages/admin/WebhooksAdminPage.tsx
@@ -1,0 +1,372 @@
+import { useState } from 'react'
+import { Webhook, Plus, Trash2, Send, Eye, CheckCircle2, XCircle, Pencil } from 'lucide-react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { webhooksApi, type WebhookEndpoint, type WebhookDelivery } from '@/lib/api'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from '@/components/ui/dialog'
+import {
+  Sheet, SheetContent, SheetHeader, SheetTitle,
+} from '@/components/ui/sheet'
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+
+// ─── Endpoint form dialog ─────────────────────────────────────────────────────
+
+function EndpointDialog({
+  open,
+  onClose,
+  endpoint,
+  allEvents,
+}: {
+  open: boolean
+  onClose: () => void
+  endpoint?: WebhookEndpoint
+  allEvents: string[]
+}) {
+  const qc = useQueryClient()
+  const isEdit = !!endpoint
+  const [url, setUrl] = useState(endpoint?.url ?? '')
+  const [secret, setSecret] = useState('')
+  const [enabled, setEnabled] = useState(endpoint?.enabled ?? true)
+  const [selectedEvents, setSelectedEvents] = useState<Set<string>>(
+    new Set(endpoint?.events ?? []),
+  )
+
+  function toggleEvent(event: string) {
+    setSelectedEvents((prev) => {
+      const next = new Set(prev)
+      if (next.has(event)) next.delete(event)
+      else next.add(event)
+      return next
+    })
+  }
+
+  function toggleGroup(events: string[]) {
+    const allSelected = events.every((e) => selectedEvents.has(e))
+    setSelectedEvents((prev) => {
+      const next = new Set(prev)
+      if (allSelected) events.forEach((e) => next.delete(e))
+      else events.forEach((e) => next.add(e))
+      return next
+    })
+  }
+
+  const save = useMutation({
+    mutationFn: () => {
+      const body = { url, events: [...selectedEvents], ...(secret ? { secret } : {}), enabled }
+      return isEdit
+        ? webhooksApi.update(endpoint!.id, body)
+        : webhooksApi.create(body)
+    },
+    onSuccess: (data) => {
+      if (!isEdit) {
+        const created = (data as { data: WebhookEndpoint & { secret: string } }).data
+        toast.success(`Endpoint created. Secret: ${created.secret}`, { duration: 15000, description: 'Copy this secret now — it will not be shown again.' })
+      } else {
+        toast.success('Endpoint updated')
+      }
+      qc.invalidateQueries({ queryKey: ['webhooks'] })
+      onClose()
+    },
+    onError: () => toast.error(isEdit ? 'Failed to update endpoint' : 'Failed to create endpoint'),
+  })
+
+  const grouped = allEvents.reduce<Record<string, string[]>>((acc, e) => {
+    const prefix = e.split('.')[0]
+    ;(acc[prefix] ??= []).push(e)
+    return acc
+  }, {})
+
+  const canSave = url.trim().length > 0 && selectedEvents.size > 0
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Endpoint' : 'Add Webhook Endpoint'}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-1">
+          <div>
+            <Label htmlFor="ep-url">URL *</Label>
+            <Input id="ep-url" className="mt-1.5" placeholder="https://example.com/webhook" value={url} onChange={(e) => setUrl(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="ep-secret">{isEdit ? 'New secret (leave blank to keep existing)' : 'Secret (optional — auto-generated if blank)'}</Label>
+            <Input id="ep-secret" className="mt-1.5" type="password" placeholder={isEdit ? 'Leave blank to keep existing' : 'Auto-generated'} value={secret} onChange={(e) => setSecret(e.target.value)} />
+          </div>
+          <div className="flex items-center gap-2">
+            <input type="checkbox" id="ep-enabled" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} className="h-4 w-4 rounded border-border" />
+            <Label htmlFor="ep-enabled">Enabled</Label>
+          </div>
+          <div>
+            <Label>Events *</Label>
+            <div className="mt-2 space-y-3 rounded-md border p-3 max-h-64 overflow-y-auto">
+              {Object.entries(grouped).map(([prefix, events]) => (
+                <div key={prefix}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <input
+                      type="checkbox"
+                      id={`group-${prefix}`}
+                      checked={events.every((e) => selectedEvents.has(e))}
+                      onChange={() => toggleGroup(events)}
+                      className="h-4 w-4 rounded border-border"
+                    />
+                    <label htmlFor={`group-${prefix}`} className="text-sm font-medium capitalize cursor-pointer">{prefix}</label>
+                  </div>
+                  <div className="ml-6 space-y-1">
+                    {events.map((e) => (
+                      <div key={e} className="flex items-center gap-2">
+                        <input type="checkbox" id={`ev-${e}`} checked={selectedEvents.has(e)} onChange={() => toggleEvent(e)} className="h-4 w-4 rounded border-border" />
+                        <label htmlFor={`ev-${e}`} className="text-xs font-mono cursor-pointer">{e}</label>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button onClick={() => save.mutate()} disabled={!canSave || save.isPending}>
+            {save.isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create endpoint'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Delivery log sheet ───────────────────────────────────────────────────────
+
+function DeliveryLogSheet({ endpoint, onClose }: { endpoint: WebhookEndpoint; onClose: () => void }) {
+  const [page, setPage] = useState(1)
+  const { data, isLoading } = useQuery({
+    queryKey: ['webhook-deliveries', endpoint.id, page],
+    queryFn: () => webhooksApi.deliveries(endpoint.id, page),
+    select: (r) => r,
+  })
+
+  return (
+    <Sheet open onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="truncate">Deliveries — {endpoint.url}</SheetTitle>
+        </SheetHeader>
+        <div className="mt-4">
+          {isLoading ? (
+            <div className="space-y-2">{Array.from({ length: 5 }).map((_, i) => <Skeleton key={i} className="h-9 w-full" />)}</div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Event</TableHead>
+                    <TableHead>Code</TableHead>
+                    <TableHead>Attempt</TableHead>
+                    <TableHead>Time</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data?.data.length === 0 ? (
+                    <TableRow><TableCell colSpan={5} className="text-center text-muted-foreground py-8">No deliveries yet</TableCell></TableRow>
+                  ) : data?.data.map((d: WebhookDelivery) => (
+                    <TableRow key={d.id}>
+                      <TableCell>{d.success ? <CheckCircle2 className="h-4 w-4 text-green-500" /> : <XCircle className="h-4 w-4 text-destructive" />}</TableCell>
+                      <TableCell className="font-mono text-xs">{d.event}</TableCell>
+                      <TableCell>{d.statusCode ?? '—'}</TableCell>
+                      <TableCell>{d.attempt}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">{new Date(d.createdAt).toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {data?.meta && data.meta.totalPages > 1 && (
+                <div className="flex items-center justify-between mt-3 text-sm">
+                  <span className="text-muted-foreground">Page {data.meta.page} of {data.meta.totalPages}</span>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="outline" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Previous</Button>
+                    <Button size="sm" variant="outline" disabled={page >= data.meta.totalPages} onClick={() => setPage((p) => p + 1)}>Next</Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export default function WebhooksAdminPage() {
+  const qc = useQueryClient()
+  const [showCreate, setShowCreate] = useState(false)
+  const [editing, setEditing] = useState<WebhookEndpoint | null>(null)
+  const [deleting, setDeleting] = useState<WebhookEndpoint | null>(null)
+  const [viewingDeliveries, setViewingDeliveries] = useState<WebhookEndpoint | null>(null)
+
+  const { data: endpoints, isLoading } = useQuery({
+    queryKey: ['webhooks'],
+    queryFn: () => webhooksApi.list(),
+    select: (r) => r.data,
+  })
+
+  const { data: allEvents = [] } = useQuery({
+    queryKey: ['webhook-events'],
+    queryFn: () => webhooksApi.listEvents(),
+    select: (r) => r.data,
+  })
+
+  const deleteEndpoint = useMutation({
+    mutationFn: (id: string) => webhooksApi.delete(id),
+    onSuccess: () => {
+      toast.success('Endpoint deleted')
+      qc.invalidateQueries({ queryKey: ['webhooks'] })
+      setDeleting(null)
+    },
+    onError: () => toast.error('Failed to delete endpoint'),
+  })
+
+  const ping = useMutation({
+    mutationFn: (id: string) => webhooksApi.ping(id),
+    onSuccess: () => toast.success('Ping sent'),
+    onError: () => toast.error('Ping failed'),
+  })
+
+  const toggleEnabled = useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      webhooksApi.update(id, { enabled }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['webhooks'] }),
+    onError: () => toast.error('Failed to update endpoint'),
+  })
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Webhook className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold">Webhooks</h1>
+        </div>
+        <Button onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add endpoint
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Endpoints</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-4 space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}
+            </div>
+          ) : endpoints?.length === 0 ? (
+            <p className="text-center text-muted-foreground py-12">No webhook endpoints configured.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>URL</TableHead>
+                  <TableHead>Events</TableHead>
+                  <TableHead>Enabled</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {endpoints?.map((ep) => (
+                  <TableRow key={ep.id}>
+                    <TableCell className="font-mono text-sm max-w-xs truncate">{ep.url}</TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1 max-w-xs">
+                        {ep.events.slice(0, 4).map((e) => (
+                          <Badge key={e} variant="secondary" className="text-xs font-mono">{e}</Badge>
+                        ))}
+                        {ep.events.length > 4 && (
+                          <Badge variant="outline" className="text-xs">+{ep.events.length - 4} more</Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        checked={ep.enabled}
+                        onChange={(e) => toggleEnabled.mutate({ id: ep.id, enabled: e.target.checked })}
+                        className="h-4 w-4 rounded border-border"
+                      />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button size="icon" variant="ghost" title="View deliveries" onClick={() => setViewingDeliveries(ep)}>
+                          <Eye className="h-4 w-4" />
+                        </Button>
+                        <Button size="icon" variant="ghost" title="Send ping" onClick={() => ping.mutate(ep.id)} disabled={ping.isPending}>
+                          <Send className="h-4 w-4" />
+                        </Button>
+                        <Button size="icon" variant="ghost" title="Edit" onClick={() => setEditing(ep)}>
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button size="icon" variant="ghost" title="Delete" onClick={() => setDeleting(ep)}>
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {showCreate && (
+        <EndpointDialog open onClose={() => setShowCreate(false)} allEvents={allEvents} />
+      )}
+
+      {editing && (
+        <EndpointDialog open onClose={() => setEditing(null)} endpoint={editing} allEvents={allEvents} />
+      )}
+
+      {viewingDeliveries && (
+        <DeliveryLogSheet endpoint={viewingDeliveries} onClose={() => setViewingDeliveries(null)} />
+      )}
+
+      <AlertDialog open={!!deleting} onOpenChange={(o) => !o && setDeleting(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete endpoint?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the endpoint <span className="font-mono">{deleting?.url}</span> and all its delivery history.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => deleting && deleteEndpoint.mutate(deleting.id)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -18,6 +18,7 @@ import AssetsAdminPage from './pages/admin/AssetsAdminPage'
 import LeasesAdminPage from './pages/admin/LeasesAdminPage'
 import GroupsAdminPage from './pages/admin/GroupsAdminPage'
 import DepartmentsAdminPage from './pages/admin/DepartmentsAdminPage'
+import WebhooksAdminPage from './pages/admin/WebhooksAdminPage'
 import { Loader2 } from 'lucide-react'
 
 // Lazy-load pages that pull in large dependencies (pdfjs-dist, react-konva, recharts)
@@ -141,6 +142,7 @@ export function AppRouter() {
             <Route path="/admin/settings" element={<SettingsAdminPage />} />
             <Route path="/admin/groups" element={<GroupsAdminPage />} />
             <Route path="/admin/departments" element={<DepartmentsAdminPage />} />
+            <Route path="/admin/webhooks" element={<WebhooksAdminPage />} />
           </Route>
 
           {/* SUPER_ADMIN, BUILDING_ADMIN, or FLOOR_MANAGER routes */}


### PR DESCRIPTION
## Summary

- Adds full webhook infrastructure with HMAC-SHA256 signed payloads, pg-boss retry queue, and delivery logging
- Wires 18 event types across bookings, queue, assets, asset assignments, and users
- Admin UI for managing endpoints and inspecting delivery history

## What's included

**API**
- `WebhookEndpoint` and `WebhookDelivery` Prisma models + migration
- `src/lib/webhook.ts` — `dispatchWebhook`, `deliverWebhookJob` (pg-boss batch worker), HMAC signing
- `src/routes/webhooks.ts` — `GET/POST/PATCH/DELETE /api/v1/webhooks`, ping, paginated delivery log; tagged for Swagger
- `webhook-delivery` pg-boss queue with retry limit 5, exponential backoff, 24h expiry
- `dispatchWebhook` called from: bookings (created/modified/cancelled/completed), queue (joined/cancelled/claimed/promoted/expired), assets (created/updated/status_changed), asset assignments (created/returned), users (created/updated/suspended/imported via LDAP sync)

**Frontend**
- `WebhooksAdminPage` — endpoint list with inline enabled toggle, create/edit dialog with per-event toggles, delivery log sheet with pagination
- Webhooks nav item in admin sidebar
- `webhooksApi` client + types in `api.ts`
- Route at `/admin/webhooks`

**Events covered**
`booking.created` · `booking.modified` · `booking.cancelled` · `booking.completed` · `queue.joined` · `queue.promoted` · `queue.claimed` · `queue.expired` · `queue.cancelled` · `asset.created` · `asset.updated` · `asset.status_changed` · `asset_assignment.created` · `asset_assignment.returned` · `user.created` · `user.updated` · `user.suspended` · `user.imported`

Closes #82