### PR TITLE
feat(rbac): clarity overhaul — provenance, symmetric access, inspectors

### DIFF
--- a/apps/api/prisma/migrations/20260604010000_rbac_clarity/migration.sql
+++ b/apps/api/prisma/migrations/20260604010000_rbac_clarity/migration.sql
@@ -1,0 +1,24 @@
+-- RBAC clarity changes:
+--   1. Provenance (MANUAL vs IDP) on group memberships and role grants so
+--      directory sync never silently undoes admin-made changes.
+--   2. Last-seen IdP group values per user (for the mapping dry-run + copy help).
+--   3. Drop the unused VIEWER / USER values from ResourceRoleType.
+
+-- 1 + 2 — RoleSource enum and provenance columns
+CREATE TYPE "RoleSource" AS ENUM ('MANUAL', 'IDP');
+
+ALTER TABLE "UserGroupMember"  ADD COLUMN "source" "RoleSource" NOT NULL DEFAULT 'MANUAL';
+ALTER TABLE "UserResourceRole" ADD COLUMN "source" "RoleSource" NOT NULL DEFAULT 'MANUAL';
+ALTER TABLE "GroupResourceRole" ADD COLUMN "source" "RoleSource" NOT NULL DEFAULT 'MANUAL';
+
+ALTER TABLE "User" ADD COLUMN "globalRoleSource" "RoleSource" NOT NULL DEFAULT 'MANUAL';
+ALTER TABLE "User" ADD COLUMN "lastIdpGroups" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "User" ADD COLUMN "lastSsoLoginAt" TIMESTAMP(3);
+
+-- 3 — Recreate ResourceRoleType without the unused VIEWER / USER values.
+-- Safe because no rows reference them (they were never assigned by any code path).
+ALTER TYPE "ResourceRoleType" RENAME TO "ResourceRoleType_old";
+CREATE TYPE "ResourceRoleType" AS ENUM ('BUILDING_ADMIN', 'FLOOR_MANAGER');
+ALTER TABLE "UserResourceRole"  ALTER COLUMN "role" TYPE "ResourceRoleType" USING ("role"::text::"ResourceRoleType");
+ALTER TABLE "GroupResourceRole" ALTER COLUMN "role" TYPE "ResourceRoleType" USING ("role"::text::"ResourceRoleType");
+DROP TYPE "ResourceRoleType_old";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -30,8 +30,14 @@ enum GlobalRole {
 enum ResourceRoleType {
   BUILDING_ADMIN
   FLOOR_MANAGER
-  USER
-  VIEWER
+}
+
+/// Provenance of a group membership or role grant: set by an admin (MANUAL) or
+/// derived from an IdP group claim on SSO login (IDP). Directory sync only
+/// evicts/downgrades IDP-sourced grants so it never undoes manual changes.
+enum RoleSource {
+  MANUAL
+  IDP
 }
 
 enum ResourceScopeType {
@@ -422,8 +428,16 @@ model User {
   externalId              String?
   accountStatus           AccountStatus @default(ACTIVE)
   globalRole              GlobalRole    @default(USER)
+  /// Provenance of globalRole. When IDP, directory sync may downgrade it; when
+  /// MANUAL (an admin set it), sync leaves it untouched.
+  globalRoleSource        RoleSource    @default(MANUAL)
   departmentId            String?
   notificationPreferences Json          @default("{}")
+  /// Raw IdP group values received on the user's most recent SSO/LDAP login.
+  /// Surfaced in the admin UI so admins can copy exact group identifiers when
+  /// configuring mappings, and used by the mapping dry-run preview.
+  lastIdpGroups           String[]      @default([])
+  lastSsoLoginAt          DateTime?
   createdAt               DateTime      @default(now())
   updatedAt               DateTime      @updatedAt
 
@@ -467,9 +481,10 @@ model UserGroup {
 model UserGroupMember {
   groupId   String
   userId    String
-  createdAt DateTime  @default(now())
-  group     UserGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  source    RoleSource @default(MANUAL)
+  createdAt DateTime   @default(now())
+  group     UserGroup  @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([groupId, userId])
 }
@@ -501,6 +516,7 @@ model UserResourceRole {
   scopeType  ResourceScopeType
   buildingId String?
   floorId    String?
+  source     RoleSource        @default(MANUAL)
   createdAt  DateTime          @default(now())
   user       User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   building   Building?         @relation(fields: [buildingId], references: [id], onDelete: Cascade)
@@ -517,6 +533,7 @@ model GroupResourceRole {
   scopeType  ResourceScopeType
   buildingId String?
   floorId    String?
+  source     RoleSource        @default(MANUAL)
   createdAt  DateTime          @default(now())
   group      UserGroup         @relation(fields: [groupId], references: [id], onDelete: Cascade)
   building   Building?         @relation(fields: [buildingId], references: [id], onDelete: Cascade)

--- a/apps/api/src/lib/group-mapping.ts
+++ b/apps/api/src/lib/group-mapping.ts
@@ -1,5 +1,17 @@
 import { prisma } from './prisma.js'
-import { GlobalRole } from '@roomer/shared'
+import { GlobalRole, RoleSource } from '@roomer/shared'
+
+/**
+ * Record the raw IdP group values seen on this login so admins can copy exact
+ * identifiers when configuring mappings, and the mapping dry-run can use them.
+ * Safe to call on every SSO/LDAP login regardless of whether mappings exist.
+ */
+export async function recordLastIdpGroups(userId: string, idpGroups: string[]): Promise<void> {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { lastIdpGroups: idpGroups, lastSsoLoginAt: new Date() },
+  })
+}
 
 export interface GroupMapping {
   /** The group name or identifier as it comes from the IdP (e.g. "Admins" or full LDAP DN) */
@@ -36,6 +48,11 @@ function groupMatches(g: string, idpGroup: string): boolean {
   const ng = normaliseDn(g)
   const ni = normaliseDn(idpGroup)
   return ng === ni
+}
+
+/** True when any of the supplied IdP group values matches the configured idpGroup. */
+export function idpGroupMatchesAny(idpGroups: string[], idpGroup: string): boolean {
+  return idpGroups.some((g) => groupMatches(g, idpGroup))
 }
 
 /**
@@ -85,21 +102,23 @@ export async function applyGroupMappings(
   }
 
   if (sync) {
-    // Remove user from mapped groups they no longer match
+    // Remove user from mapped groups they no longer match — but ONLY IDP-sourced
+    // memberships, so a membership an admin added manually is never evicted.
     const staleGroupIds = [...allMappedGroupIds].filter((gid) => !matchedGroupIds.includes(gid))
     if (staleGroupIds.length) {
       await prisma.userGroupMember.deleteMany({
-        where: { userId, groupId: { in: staleGroupIds } },
+        where: { userId, groupId: { in: staleGroupIds }, source: RoleSource.IDP },
       })
     }
   }
 
-  // Add user to each matched Roomer group
+  // Add user to each matched Roomer group, tagging the membership as IDP-sourced.
+  // If the membership already exists as a manual grant we leave its source alone.
   for (const groupId of matchedGroupIds) {
     try {
       await prisma.userGroupMember.upsert({
         where: { groupId_userId: { groupId, userId } },
-        create: { groupId, userId },
+        create: { groupId, userId, source: RoleSource.IDP },
         update: {},
       })
     } catch {
@@ -117,17 +136,24 @@ export async function applyGroupMappings(
 
   const hasAdminRole = directAdminGrant || effectiveGroups.some((g) => g.globalRole === GlobalRole.SUPER_ADMIN)
 
-  if (sync) {
-    // Re-derive role; may downgrade from SUPER_ADMIN → USER if no matching grants remain
+  if (hasAdminRole) {
+    // IdP grants admin — record IDP provenance so a later sync can revoke it.
     await prisma.user.update({
       where: { id: userId },
-      data: { globalRole: hasAdminRole ? GlobalRole.SUPER_ADMIN : GlobalRole.USER },
+      data: { globalRole: GlobalRole.SUPER_ADMIN, globalRoleSource: RoleSource.IDP },
     })
-  } else if (hasAdminRole) {
-    // Legacy: only elevate, never downgrade
-    await prisma.user.update({
+  } else if (sync) {
+    // No IdP admin grant. Only downgrade if the current admin role was itself
+    // IDP-derived — never strip an admin role an operator set manually.
+    const current = await prisma.user.findUnique({
       where: { id: userId },
-      data: { globalRole: GlobalRole.SUPER_ADMIN },
+      select: { globalRole: true, globalRoleSource: true },
     })
+    if (current?.globalRole === GlobalRole.SUPER_ADMIN && current.globalRoleSource === RoleSource.IDP) {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { globalRole: GlobalRole.USER, globalRoleSource: RoleSource.MANUAL },
+      })
+    }
   }
 }

--- a/apps/api/src/middleware/requireRole.ts
+++ b/apps/api/src/middleware/requireRole.ts
@@ -3,8 +3,6 @@ import { GlobalRole, ResourceRoleType, ResourceScopeType } from '@roomer/shared'
 import { prisma } from '../lib/prisma.js'
 
 const ROLE_HIERARCHY: Record<ResourceRoleType, number> = {
-  [ResourceRoleType.VIEWER]: 0,
-  [ResourceRoleType.USER]: 1,
   [ResourceRoleType.FLOOR_MANAGER]: 2,
   [ResourceRoleType.BUILDING_ADMIN]: 3,
 }

--- a/apps/api/src/routes/auth-enterprise.ts
+++ b/apps/api/src/routes/auth-enterprise.ts
@@ -4,7 +4,7 @@ import { env } from '../env.js'
 import { getOidcClientConfig, getOidcConfig, generateState, generateNonce } from '../lib/oidc.js'
 import { buildAuthorizationUrl, authorizationCodeGrant, fetchUserInfo, skipSubjectCheck } from 'openid-client'
 import { getSamlConfig, buildSaml, extractEmailFromProfile, extractDisplayNameFromProfile, extractGroupsFromProfile, extractDepartmentFromProfile, type SamlProfile } from '../lib/saml.js'
-import { applyGroupMappings } from '../lib/group-mapping.js'
+import { applyGroupMappings, recordLastIdpGroups } from '../lib/group-mapping.js'
 import { signAccessToken, TOKEN_COOKIE, TOKEN_COOKIE_OPTS, TOKEN_MAX_AGE } from '../lib/jwt.js'
 import type { User } from '@prisma/client'
 
@@ -173,6 +173,7 @@ export async function enterpriseAuthRoutes(fastify: FastifyInstance): Promise<vo
       const groupsClaimName = cfg.groupsClaimName ?? 'groups'
       const rawGroups = (userinfo as Record<string, unknown>)[groupsClaimName]
       const idpGroups = Array.isArray(rawGroups) ? rawGroups.map(String) : []
+      await recordLastIdpGroups(user.id, idpGroups)
       if (idpGroups.length && cfg.groupMappings?.length) {
         await applyGroupMappings(user.id, idpGroups, cfg.groupMappings, true)
       }
@@ -235,6 +236,7 @@ export async function enterpriseAuthRoutes(fastify: FastifyInstance): Promise<vo
       }
 
       const idpGroups = extractGroupsFromProfile(samlProfile, cfg.groupAttribute)
+      await recordLastIdpGroups(user.id, idpGroups)
       if (idpGroups.length && cfg.groupMappings?.length) {
         await applyGroupMappings(user.id, idpGroups, cfg.groupMappings, true)
       }

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -4,7 +4,7 @@ import { prisma } from '../lib/prisma.js'
 import { loginSchema } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { authenticateWithLdap, getLdapConfig } from '../lib/ldap.js'
-import { applyGroupMappings } from '../lib/group-mapping.js'
+import { applyGroupMappings, recordLastIdpGroups } from '../lib/group-mapping.js'
 import { signAccessToken, verifyAccessToken, TOKEN_COOKIE, TOKEN_COOKIE_OPTS, TOKEN_MAX_AGE, MAX_SESSION_SECONDS } from '../lib/jwt.js'
 import { blockToken, isTokenBlocked } from '../lib/token-blocklist.js'
 
@@ -45,6 +45,7 @@ export async function authRoutes(fastify: FastifyInstance): Promise<void> {
             passwordHash: null,
           },
         })
+        await recordLastIdpGroups(user.id, ldapResult.groups)
         const ldapCfg = await getLdapConfig()
         const mappings = ldapCfg?.groupMappings ?? []
         if (ldapResult.groups.length && mappings.length) {

--- a/apps/api/src/routes/buildings.ts
+++ b/apps/api/src/routes/buildings.ts
@@ -8,6 +8,40 @@ import { z } from 'zod'
 export async function buildingRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Buildings'], ...route.schema } })
 
+  // GET /buildings/:id/access-summary — "who can access / manage this building?"
+  fastify.get('/:id/access-summary', { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const building = await prisma.building.findUnique({ where: { id }, select: { id: true, name: true } })
+    if (!building) return reply.status(404).send({ error: { message: 'Building not found', code: 'NOT_FOUND' } })
+
+    const [accessGroups, directManagers, groupManagers] = await Promise.all([
+      prisma.groupBuildingAccess.findMany({ where: { buildingId: id }, select: { group: { select: { id: true, name: true } } } }),
+      prisma.userResourceRole.findMany({
+        where: { scopeType: 'BUILDING', buildingId: id, role: 'BUILDING_ADMIN' },
+        select: { source: true, user: { select: { id: true, displayName: true, email: true } } },
+      }),
+      prisma.groupResourceRole.findMany({
+        where: { scopeType: 'BUILDING', buildingId: id, role: 'BUILDING_ADMIN' },
+        select: { source: true, group: { select: { id: true, name: true, _count: { select: { members: true } } } } },
+      }),
+    ])
+
+    return reply.status(200).send({
+      data: {
+        buildingId: building.id,
+        name: building.name,
+        access: {
+          restricted: accessGroups.length > 0,
+          groups: accessGroups.map((a) => a.group),
+        },
+        managers: {
+          direct: directManagers.map((m) => ({ ...m.user, source: m.source })),
+          viaGroups: groupManagers.map((m) => ({ ...m.group, memberCount: m.group._count.members, source: m.source })),
+        },
+      },
+    })
+  })
+
   // GET /buildings — list buildings the requesting user can access
   // SUPER_ADMINs see every building. Regular users only see buildings that are
   // either unrestricted (no GroupBuildingAccess rows) or have a matching group.

--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -4,13 +4,57 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../lib/prisma.js'
 import { createFloorSchema, updateFloorSchema, GlobalRole } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
-import { isFloorManagerForFloor, isBuildingManagerForBuilding } from '../middleware/requireRole.js'
+import { isFloorManagerForFloor, isBuildingManagerForBuilding, requireGlobalRole } from '../middleware/requireRole.js'
 import { saveFloorPlan, resolveStoragePath, deleteFile } from '../lib/storage.js'
 import { canUserAccessBuilding } from './groups.js'
 import { z } from 'zod'
 
 export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Floors'], ...route.schema } })
+
+  // GET /floors/:id/access-summary — "who can access / manage this floor?"
+  fastify.get('/:id/access-summary', { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const floor = await prisma.floor.findUnique({
+      where: { id },
+      select: { id: true, name: true, building: { select: { id: true, name: true } } },
+    })
+    if (!floor) return reply.status(404).send({ error: { message: 'Floor not found', code: 'NOT_FOUND' } })
+
+    const [accessGroups, directManagers, groupManagers, buildingAdmins] = await Promise.all([
+      prisma.groupFloorAccess.findMany({ where: { floorId: id }, select: { group: { select: { id: true, name: true } } } }),
+      prisma.userResourceRole.findMany({
+        where: { scopeType: 'FLOOR', floorId: id, role: 'FLOOR_MANAGER' },
+        select: { source: true, user: { select: { id: true, displayName: true, email: true } } },
+      }),
+      prisma.groupResourceRole.findMany({
+        where: { scopeType: 'FLOOR', floorId: id, role: 'FLOOR_MANAGER' },
+        select: { source: true, group: { select: { id: true, name: true, _count: { select: { members: true } } } } },
+      }),
+      // Building admins inherit floor-manager rights on every floor in their building
+      prisma.userResourceRole.findMany({
+        where: { scopeType: 'BUILDING', buildingId: floor.building.id, role: 'BUILDING_ADMIN' },
+        select: { user: { select: { id: true, displayName: true, email: true } } },
+      }),
+    ])
+
+    return reply.status(200).send({
+      data: {
+        floorId: floor.id,
+        name: floor.name,
+        building: floor.building,
+        access: {
+          restricted: accessGroups.length > 0,
+          groups: accessGroups.map((a) => a.group),
+        },
+        managers: {
+          direct: directManagers.map((m) => ({ ...m.user, source: m.source })),
+          viaGroups: groupManagers.map((m) => ({ ...m.group, memberCount: m.group._count.members, source: m.source })),
+          inheritedFromBuildingAdmins: buildingAdmins.map((m) => m.user),
+        },
+      },
+    })
+  })
 
   // GET /floors/:id — floor with zones, bookable assets, floorPlan
   fastify.get('/:id', { preHandler: [requireAuth] }, async (request, reply) => {

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -281,37 +281,42 @@ export async function canUserAccessBuilding(userId: string, buildingId: string):
 }
 
 /**
- * Returns true if the user is allowed to book in the given building/floor.
+ * Floor-centric access check — symmetric with canUserAccessBuilding.
  *
- * Two-stage check:
- *   1. Building-centric: if the building has GroupBuildingAccess rows, the user
- *      must be in at least one of those groups.
- *   2. Floor-centric (user-driven): for each of the user's groups that carries
- *      explicit floor restrictions, the target floor must be listed.
+ * A floor is "restricted" when at least one GroupFloorAccess row points to it.
+ * If restricted, the user must be a member of at least one of those groups.
+ * If unrestricted (no rows), any authenticated user can access it.
+ *
+ * (Previously this was "user-centric": a floor only excluded users who happened
+ * to be in some floor-restricted group, so a user in no such group could reach
+ * any floor. That asymmetry with building access was a frequent misconfiguration
+ * trap — you couldn't actually lock a floor down. This now mirrors buildings.)
+ */
+export async function canUserAccessFloor(userId: string, floorId: string): Promise<boolean> {
+  const accessCount = await prisma.groupFloorAccess.count({ where: { floorId } })
+  if (accessCount === 0) return true  // open floor — no restrictions configured
+
+  const userGroupIds = (
+    await prisma.userGroupMember.findMany({ where: { userId }, select: { groupId: true } })
+  ).map((m) => m.groupId)
+
+  if (userGroupIds.length === 0) return false
+
+  const match = await prisma.groupFloorAccess.findFirst({
+    where: { floorId, groupId: { in: userGroupIds } },
+  })
+  return match !== null
+}
+
+/**
+ * Returns true if the user is allowed to book in the given building/floor.
+ * Both gates use the same "restricted only if a rule exists, else open" model.
  */
 export async function checkGroupAccess(
   userId: string,
   buildingId: string,
   floorId: string,
 ): Promise<boolean> {
-  // Stage 1 — building-level gate
-  const buildingOk = await canUserAccessBuilding(userId, buildingId)
-  if (!buildingOk) return false
-
-  // Stage 2 — floor-level gate (user-centric: only applies when the user's own
-  // groups carry explicit floor restrictions)
-  const memberships = await prisma.userGroupMember.findMany({
-    where: { userId },
-    include: { group: { include: { floorAccess: true } } },
-  })
-
-  const groupsWithFloorRules = memberships
-    .map((m) => m.group)
-    .filter((g) => g.floorAccess.length > 0)
-
-  if (groupsWithFloorRules.length === 0) return true  // no floor restrictions
-
-  return groupsWithFloorRules.some((group) =>
-    group.floorAccess.map((f) => f.floorId).includes(floorId)
-  )
+  if (!(await canUserAccessBuilding(userId, buildingId))) return false
+  return canUserAccessFloor(userId, floorId)
 }

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -10,6 +10,7 @@ import { invalidateOidcCache } from '../lib/oidc.js'
 import { syncLdapUsers, getLdapConfig } from '../lib/ldap.js'
 import { hashScimToken, generateScimToken } from '../lib/scim-helpers.js'
 import { findAuthConfig, listAuthConfigs, upsertAuthConfig } from '../lib/prisma.js'
+import { idpGroupMatchesAny } from '../lib/group-mapping.js'
 import { saveBrandingImage, resolveStoragePath } from '../lib/storage.js'
 import { DEFAULT_TEMPLATE_STRINGS, interpolateTemplate, stripHtmlToText, formatDate, sendEmail } from '../lib/mailer.js'
 import { z } from 'zod'
@@ -459,6 +460,77 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
         const message = err instanceof Error ? err.message : 'Unknown error'
         return reply.status(502).send({ error: { message: `LDAP sync failed: ${message}`, code: 'LDAP_SYNC_ERROR' } })
       }
+    },
+  )
+
+  // POST /settings/auth-config/:provider/test-mapping — dry-run IdP group → Roomer
+  // resolution. Evaluate against provided groups, a specific user's last-seen IdP
+  // groups, or the union of all users' last-seen groups (to flag dead mappings).
+  fastify.post(
+    '/auth-config/:provider/test-mapping',
+    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)], config: { rateLimit: { max: 30, timeWindow: '1 minute' } } },
+    async (request, reply) => {
+      const { provider } = request.params as { provider: string }
+      const upperProvider = provider.toUpperCase() as ProviderKey
+      if (!ALLOWED_PROVIDERS.includes(upperProvider)) {
+        return reply.status(400).send({ error: { message: `Unknown provider: ${provider}`, code: 'VALIDATION_ERROR' } })
+      }
+
+      const parsed = z.object({
+        groups: z.array(z.string()).optional(),
+        userId: z.string().optional(),
+      }).safeParse(request.body ?? {})
+      if (!parsed.success) {
+        return reply.status(400).send({ error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: parsed.error.flatten() } })
+      }
+
+      const cfg = await findAuthConfig(upperProvider)
+      const mappings = (((cfg?.config as Record<string, unknown> | undefined)?.groupMappings) ?? []) as Array<{ idpGroup: string; roomerGroupId?: string; targetGlobalRole?: string }>
+
+      let inputGroups: string[]
+      let evaluatedAgainst: 'provided' | 'user' | 'all-known'
+      if (parsed.data.groups && parsed.data.groups.length > 0) {
+        inputGroups = parsed.data.groups
+        evaluatedAgainst = 'provided'
+      } else if (parsed.data.userId) {
+        const u = await prisma.user.findUnique({ where: { id: parsed.data.userId }, select: { lastIdpGroups: true } })
+        inputGroups = u?.lastIdpGroups ?? []
+        evaluatedAgainst = 'user'
+      } else {
+        const all = await prisma.user.findMany({ where: { lastIdpGroups: { isEmpty: false } }, select: { lastIdpGroups: true } })
+        inputGroups = [...new Set(all.flatMap((u) => u.lastIdpGroups))]
+        evaluatedAgainst = 'all-known'
+      }
+
+      const groupIds = mappings.map((m) => m.roomerGroupId).filter((x): x is string => !!x)
+      const groups = groupIds.length
+        ? await prisma.userGroup.findMany({ where: { id: { in: groupIds } }, select: { id: true, name: true, globalRole: true } })
+        : []
+      const byId = new Map(groups.map((g) => [g.id, g]))
+
+      const perMapping = mappings.map((m) => {
+        const matched = idpGroupMatchesAny(inputGroups, m.idpGroup)
+        const rg = m.roomerGroupId ? byId.get(m.roomerGroupId) : undefined
+        const confersAdmin = m.targetGlobalRole === 'SUPER_ADMIN' || rg?.globalRole === 'SUPER_ADMIN'
+        return {
+          idpGroup: m.idpGroup,
+          matched,
+          roomerGroup: rg ? { id: rg.id, name: rg.name } : null,
+          confersAdmin,
+        }
+      })
+
+      return reply.status(200).send({
+        data: {
+          evaluatedAgainst,
+          inputGroups,
+          mappings: perMapping,
+          resolvedGroups: perMapping.filter((p) => p.matched && p.roomerGroup).map((p) => p.roomerGroup),
+          resolvedGlobalRole: perMapping.some((p) => p.matched && p.confersAdmin) ? 'SUPER_ADMIN' : 'USER',
+          // Configured mappings that did not match any evaluated group — likely typos / dead rules.
+          unmatchedMappings: perMapping.filter((p) => !p.matched).map((p) => p.idpGroup),
+        },
+      })
     },
   )
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import bcryptjs from 'bcryptjs'
 import crypto from 'crypto'
 import { prisma } from '../lib/prisma.js'
-import { GlobalRole, ResourceRoleType, ResourceScopeType } from '@roomer/shared'
+import { GlobalRole, ResourceRoleType, ResourceScopeType, RoleSource } from '@roomer/shared'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { requireGlobalRole } from '../middleware/requireRole.js'
 import { enqueueNotification } from '../lib/queue.js'
@@ -262,7 +262,12 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
     try {
       const updated = await prisma.user.update({
         where: { id },
-        data: result.data,
+        data: {
+          ...result.data,
+          // An admin explicitly setting the role marks it MANUAL so directory
+          // sync will not later downgrade it.
+          ...(result.data.globalRole !== undefined ? { globalRoleSource: RoleSource.MANUAL } : {}),
+        },
         select: {
           id: true,
           email: true,
@@ -363,6 +368,99 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.status(200).send({ data: { ok: true } })
     },
   )
+
+  // GET /users/:id/effective-access — explain WHAT a user can do and WHERE each
+  // permission comes from (provenance). Visible to the user themselves or admins.
+  fastify.get('/:id/effective-access', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const isSelf = request.user.id === id
+    const isAdmin = request.user.globalRole === GlobalRole.SUPER_ADMIN
+    if (!isSelf && !isAdmin) {
+      return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: {
+        id: true, email: true, displayName: true, globalRole: true, globalRoleSource: true,
+        lastIdpGroups: true, lastSsoLoginAt: true,
+        resourceRoles: {
+          select: {
+            role: true, scopeType: true, source: true,
+            building: { select: { id: true, name: true } },
+            floor: { select: { id: true, name: true, building: { select: { id: true, name: true } } } },
+          },
+        },
+        groupMemberships: {
+          select: {
+            source: true,
+            group: {
+              select: {
+                id: true, name: true, globalRole: true,
+                groupResourceRoles: {
+                  select: {
+                    role: true, scopeType: true,
+                    building: { select: { id: true, name: true } },
+                    floor: { select: { id: true, name: true, building: { select: { id: true, name: true } } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    if (!user) {
+      return reply.status(404).send({ error: { message: 'User not found', code: 'NOT_FOUND' } })
+    }
+
+    type Grant = { scope: 'BUILDING' | 'FLOOR'; role: string; targetId: string; targetName: string; buildingName?: string; via: string; source: string }
+    const grants: Grant[] = []
+
+    for (const r of user.resourceRoles) {
+      if (r.scopeType === 'BUILDING' && r.building) {
+        grants.push({ scope: 'BUILDING', role: r.role, targetId: r.building.id, targetName: r.building.name, via: 'Direct grant', source: r.source })
+      } else if (r.scopeType === 'FLOOR' && r.floor) {
+        grants.push({ scope: 'FLOOR', role: r.role, targetId: r.floor.id, targetName: r.floor.name, buildingName: r.floor.building?.name, via: 'Direct grant', source: r.source })
+      }
+    }
+
+    const groups = user.groupMemberships.map((m) => ({
+      id: m.group.id,
+      name: m.group.name,
+      source: m.source,
+      confersAdmin: m.group.globalRole === GlobalRole.SUPER_ADMIN,
+    }))
+
+    for (const m of user.groupMemberships) {
+      for (const r of m.group.groupResourceRoles) {
+        if (r.scopeType === 'BUILDING' && r.building) {
+          grants.push({ scope: 'BUILDING', role: r.role, targetId: r.building.id, targetName: r.building.name, via: `Group "${m.group.name}"`, source: m.source })
+        } else if (r.scopeType === 'FLOOR' && r.floor) {
+          grants.push({ scope: 'FLOOR', role: r.role, targetId: r.floor.id, targetName: r.floor.name, buildingName: r.floor.building?.name, via: `Group "${m.group.name}"`, source: m.source })
+        }
+      }
+    }
+
+    const adminViaGroup = groups.find((g) => g.confersAdmin)
+
+    return reply.status(200).send({
+      data: {
+        user: { id: user.id, email: user.email, displayName: user.displayName },
+        globalRole: user.globalRole,
+        globalRoleSource: user.globalRoleSource,
+        globalRoleVia: user.globalRole === GlobalRole.SUPER_ADMIN
+          ? (user.globalRoleSource === RoleSource.IDP ? 'Granted via IdP group mapping' : (adminViaGroup ? `Group "${adminViaGroup.name}"` : 'Set manually'))
+          : null,
+        groups,
+        grants,
+        idp: {
+          lastSsoLoginAt: user.lastSsoLoginAt,
+          lastIdpGroups: user.lastIdpGroups,
+        },
+      },
+    })
+  })
 
   // GET /users/:id/bookings — get user's bookings
   fastify.get('/:id/bookings', { preHandler: [requireAuth] }, async (request, reply) => {

--- a/apps/web/src/components/rbac/AccessInspector.tsx
+++ b/apps/web/src/components/rbac/AccessInspector.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { usersApi, buildingsApi, floorsApi, authProvidersApi, type RoleSource, type MappingTestResult } from '@/lib/api'
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
+} from '@/components/ui/dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+/** Small provenance pill: was this granted by an admin (Manual) or the IdP (Synced)? */
+export function SourceBadge({ source }: { source: RoleSource }) {
+  return source === 'IDP'
+    ? <Badge variant="secondary" className="text-[10px]" title="Synced from your identity provider on login">Synced</Badge>
+    : <Badge variant="outline" className="text-[10px]" title="Set manually by an administrator">Manual</Badge>
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1 py-2 border-b last:border-0">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <div className="text-sm">{children}</div>
+    </div>
+  )
+}
+
+// ─── Effective access: "what can this user do, and why?" ─────────────────────
+export function EffectiveAccessDialog({
+  userId, userName, open, onOpenChange,
+}: { userId: string; userName: string; open: boolean; onOpenChange: (v: boolean) => void }) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['effective-access', userId],
+    queryFn: () => usersApi.effectiveAccess(userId).then((r) => r.data),
+    enabled: open,
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Effective access — {userName}</DialogTitle>
+          <DialogDescription>Every permission this user has, and where it comes from.</DialogDescription>
+        </DialogHeader>
+
+        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+        {isError && <p className="text-sm text-destructive">Could not load access details.</p>}
+        {data && (
+          <div className="max-h-[60vh] overflow-y-auto pr-1">
+            <Row label="Global role">
+              <span className="inline-flex items-center gap-2">
+                <Badge variant={data.globalRole === 'SUPER_ADMIN' ? 'destructive' : 'secondary'}>{data.globalRole}</Badge>
+                {data.globalRoleVia && <span className="text-xs text-muted-foreground">{data.globalRoleVia}</span>}
+              </span>
+            </Row>
+
+            <Row label="Groups">
+              {data.groups.length === 0
+                ? <span className="text-muted-foreground">None</span>
+                : (
+                  <ul className="space-y-1">
+                    {data.groups.map((g) => (
+                      <li key={g.id} className="flex items-center gap-2">
+                        <span>{g.name}</span>
+                        <SourceBadge source={g.source} />
+                        {g.confersAdmin && <Badge variant="destructive" className="text-[10px]">Grants admin</Badge>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+            </Row>
+
+            <Row label="Manager roles">
+              {data.grants.length === 0
+                ? <span className="text-muted-foreground">None</span>
+                : (
+                  <ul className="space-y-1">
+                    {data.grants.map((grant, i) => (
+                      <li key={i} className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline" className="text-[10px]">{grant.role.replace('_', ' ')}</Badge>
+                        <span>
+                          {grant.targetName}
+                          {grant.buildingName && <span className="text-muted-foreground"> · {grant.buildingName}</span>}
+                        </span>
+                        <span className="text-xs text-muted-foreground">({grant.via})</span>
+                        <SourceBadge source={grant.source} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+            </Row>
+
+            {(data.idp.lastSsoLoginAt || data.idp.lastIdpGroups.length > 0) && (
+              <Row label="Last identity-provider login">
+                <div className="space-y-1">
+                  {data.idp.lastSsoLoginAt && (
+                    <p className="text-xs text-muted-foreground">{new Date(data.idp.lastSsoLoginAt).toLocaleString()}</p>
+                  )}
+                  {data.idp.lastIdpGroups.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {data.idp.lastIdpGroups.map((g) => (
+                        <code key={g} className="rounded bg-muted px-1.5 py-0.5 text-[11px]">{g}</code>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </Row>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Access state badge for a building/floor ─────────────────────────────────
+export function AccessStateBadge({ restricted, groupCount }: { restricted: boolean; groupCount: number }) {
+  return restricted
+    ? <Badge variant="secondary" title={`Restricted to ${groupCount} group(s)`}>🔒 Restricted to {groupCount} group{groupCount === 1 ? '' : 's'}</Badge>
+    : <Badge variant="outline" title="Any signed-in user can access">🟢 Open to everyone</Badge>
+}
+
+// ─── "Who can access / manage this?" for a building or floor ──────────────────
+export function AccessSummaryDialog({
+  kind, id, name, open, onOpenChange,
+}: { kind: 'building' | 'floor'; id: string; name: string; open: boolean; onOpenChange: (v: boolean) => void }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['access-summary', kind, id],
+    queryFn: () => (kind === 'building' ? buildingsApi.accessSummary(id) : floorsApi.accessSummary(id)).then((r) => r.data),
+    enabled: open,
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Access summary — {name}</DialogTitle>
+          <DialogDescription>Who can access and who can manage this {kind}.</DialogDescription>
+        </DialogHeader>
+        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+        {data && (
+          <div className="space-y-3">
+            <Row label="Access">
+              <div className="flex items-center gap-2">
+                <AccessStateBadge restricted={data.access.restricted} groupCount={data.access.groups.length} />
+              </div>
+              {data.access.restricted && (
+                <ul className="mt-1 list-disc pl-5 text-sm text-muted-foreground">
+                  {data.access.groups.map((g) => <li key={g.id}>{g.name}</li>)}
+                </ul>
+              )}
+            </Row>
+            <Row label="Managers">
+              {data.managers.direct.length === 0 && data.managers.viaGroups.length === 0 && (!data.managers.inheritedFromBuildingAdmins?.length)
+                ? <span className="text-muted-foreground">None assigned</span>
+                : (
+                  <ul className="space-y-1">
+                    {data.managers.direct.map((m) => (
+                      <li key={m.id} className="flex items-center gap-2">{m.displayName} <span className="text-xs text-muted-foreground">{m.email}</span> <SourceBadge source={m.source} /></li>
+                    ))}
+                    {data.managers.viaGroups.map((g) => (
+                      <li key={g.id} className="flex items-center gap-2">Group “{g.name}” <span className="text-xs text-muted-foreground">({g.memberCount} members)</span> <SourceBadge source={g.source} /></li>
+                    ))}
+                    {data.managers.inheritedFromBuildingAdmins?.map((m) => (
+                      <li key={m.id} className="flex items-center gap-2 text-muted-foreground">{m.displayName} <Badge variant="outline" className="text-[10px]">via building admin</Badge></li>
+                    ))}
+                  </ul>
+                )}
+            </Row>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── IdP mapping dry-run ─────────────────────────────────────────────────────
+export function MappingTestPanel({ provider }: { provider: 'OIDC' | 'SAML' | 'LDAP' }) {
+  const [groupsText, setGroupsText] = useState('')
+  const [result, setResult] = useState<MappingTestResult | null>(null)
+
+  const run = useMutation({
+    mutationFn: (groups: string[] | undefined) => authProvidersApi.testMapping(provider, groups ? { groups } : {}).then((r) => r.data),
+    onSuccess: (r) => setResult(r),
+  })
+
+  const parsedGroups = groupsText.split(/[\n,]/).map((s) => s.trim()).filter(Boolean)
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div>
+        <p className="text-sm font-medium">Test group mapping</p>
+        <p className="text-xs text-muted-foreground">
+          Paste a user’s IdP groups (one per line) to preview which Roomer groups and role they’d receive —
+          or leave blank to evaluate against every group value seen across past logins (to spot dead rules).
+        </p>
+      </div>
+      <Textarea
+        rows={3}
+        placeholder={'cn=Engineering,ou=Groups,dc=example,dc=com\ncn=Admins,ou=Groups,dc=example,dc=com'}
+        value={groupsText}
+        onChange={(e) => setGroupsText(e.target.value)}
+        className="font-mono text-xs"
+      />
+      <div className="flex gap-2">
+        <Button size="sm" variant="outline" onClick={() => run.mutate(parsedGroups.length ? parsedGroups : undefined)} disabled={run.isPending}>
+          {run.isPending ? 'Testing…' : 'Run test'}
+        </Button>
+      </div>
+
+      {result && (
+        <div className="space-y-2 text-sm">
+          <p className="text-xs text-muted-foreground">
+            Evaluated against {result.evaluatedAgainst === 'provided' ? 'the groups you entered' : result.evaluatedAgainst === 'user' ? 'a user’s last login' : 'all groups seen across past logins'}
+            {' '}({result.inputGroups.length} group{result.inputGroups.length === 1 ? '' : 's'}).
+          </p>
+          <p>
+            Result:{' '}
+            {result.resolvedGroups.length > 0
+              ? result.resolvedGroups.map((g) => g.name).join(', ')
+              : <span className="text-muted-foreground">no groups</span>}
+            {' · role '}
+            <Badge variant={result.resolvedGlobalRole === 'SUPER_ADMIN' ? 'destructive' : 'secondary'} className="text-[10px]">{result.resolvedGlobalRole}</Badge>
+          </p>
+          {result.unmatchedMappings.length > 0 && (
+            <div className="rounded bg-amber-50 p-2 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+              <p className="font-medium">⚠ Mappings that matched nothing (possible typos):</p>
+              <ul className="mt-1 list-disc pl-4">
+                {result.unmatchedMappings.map((m) => <li key={m}><code>{m}</code></li>)}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -141,6 +141,7 @@ export const buildingsApi = {
     ),
   removeGroupManager: (id: string, groupId: string) =>
     api.delete<{ data: { ok: true } }>(`/buildings/${id}/group-managers/${groupId}`),
+  accessSummary: (id: string) => api.get<{ data: AccessSummary }>(`/buildings/${id}/access-summary`),
 }
 
 // --- Floors ---
@@ -181,6 +182,7 @@ export const floorsApi = {
     api.delete<{ data: { ok: true } }>(`/floors/${id}/group-managers/${groupId}`),
   updateFloorPlanTransform: (id: string, displayScale: number) =>
     api.patch<{ data: { displayScale: number } }>(`/floors/${id}/floor-plan/transform`, { displayScale }),
+  accessSummary: (id: string) => api.get<{ data: AccessSummary }>(`/floors/${id}/access-summary`),
 }
 
 // --- Zones ---
@@ -418,6 +420,41 @@ export const usersApi = {
     api.post<{ data: { ok: boolean } }>('/users/me/password', body),
   resetPassword: (id: string, body: { password: string }) =>
     api.post<{ data: { ok: boolean } }>(`/users/${id}/password/reset`, body),
+  effectiveAccess: (id: string) =>
+    api.get<{ data: EffectiveAccess }>(`/users/${id}/effective-access`),
+}
+
+// --- RBAC inspection types ---
+export type RoleSource = 'MANUAL' | 'IDP'
+
+export interface EffectiveAccess {
+  user: { id: string; email: string; displayName: string }
+  globalRole: string
+  globalRoleSource: RoleSource
+  globalRoleVia: string | null
+  groups: Array<{ id: string; name: string; source: RoleSource; confersAdmin: boolean }>
+  grants: Array<{ scope: 'BUILDING' | 'FLOOR'; role: string; targetId: string; targetName: string; buildingName?: string; via: string; source: RoleSource }>
+  idp: { lastSsoLoginAt: string | null; lastIdpGroups: string[] }
+}
+
+export interface AccessSummary {
+  name: string
+  building?: { id: string; name: string }
+  access: { restricted: boolean; groups: Array<{ id: string; name: string }> }
+  managers: {
+    direct: Array<{ id: string; displayName: string; email: string; source: RoleSource }>
+    viaGroups: Array<{ id: string; name: string; memberCount: number; source: RoleSource }>
+    inheritedFromBuildingAdmins?: Array<{ id: string; displayName: string; email: string }>
+  }
+}
+
+export interface MappingTestResult {
+  evaluatedAgainst: 'provided' | 'user' | 'all-known'
+  inputGroups: string[]
+  mappings: Array<{ idpGroup: string; matched: boolean; roomerGroup: { id: string; name: string } | null; confersAdmin: boolean }>
+  resolvedGroups: Array<{ id: string; name: string }>
+  resolvedGlobalRole: string
+  unmatchedMappings: string[]
 }
 
 // --- Settings ---
@@ -530,6 +567,8 @@ export interface AuthProviders {
 }
 export const authProvidersApi = {
   list: () => api.get<{ data: AuthProviders }>('/auth/providers'),
+  testMapping: (provider: string, body: { groups?: string[]; userId?: string }) =>
+    api.post<{ data: MappingTestResult }>(`/settings/auth-config/${provider}/test-mapping`, body),
 }
 
 

--- a/apps/web/src/pages/admin/BuildingDetailAdminPage.tsx
+++ b/apps/web/src/pages/admin/BuildingDetailAdminPage.tsx
@@ -10,6 +10,7 @@ import AssignmentImportDialog from '@/components/admin/AssignmentImportDialog'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { AccessSummaryDialog } from '@/components/rbac/AccessInspector'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
@@ -697,6 +698,7 @@ export default function BuildingDetailAdminPage() {
   const { buildingId } = useParams<{ buildingId: string }>()
   const [addFloorOpen, setAddFloorOpen] = useState(false)
   const [bulkAssignOpen, setBulkAssignOpen] = useState(false)
+  const [accessOpen, setAccessOpen] = useState(false)
 
   const { data: building, isLoading } = useQuery({
     queryKey: ['buildings', buildingId],
@@ -723,6 +725,9 @@ export default function BuildingDetailAdminPage() {
           )}
         </div>
         <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => setAccessOpen(true)}>
+            <Shield className="mr-2 h-4 w-4" /> Access summary
+          </Button>
           <Button variant="outline" onClick={() => setBulkAssignOpen(true)}>
             <UserPlus className="mr-2 h-4 w-4" /> Bulk assign users
           </Button>
@@ -731,6 +736,8 @@ export default function BuildingDetailAdminPage() {
           </Button>
         </div>
       </div>
+
+      <AccessSummaryDialog kind="building" id={buildingId!} name={building?.name ?? 'Building'} open={accessOpen} onOpenChange={setAccessOpen} />
 
       <BuildingManagersPanel buildingId={buildingId!} />
 

--- a/apps/web/src/pages/admin/FloorAdminPage.tsx
+++ b/apps/web/src/pages/admin/FloorAdminPage.tsx
@@ -6,13 +6,14 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import {
   Plus, Upload, List, LayoutTemplate, Pencil, Trash2, ChevronRight,
   ChevronDown, GripVertical, X, Users, UserMinus, UserPlus, FileText, Download,
-  AlertCircle, CheckCircle2,
+  AlertCircle, CheckCircle2, Shield,
 } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { floorsApi, assetsApi, zonesApi, usersApi, groupsApi } from '@/lib/api'
 import { toast } from 'sonner'
 import { FloorPlanCanvas } from '@/components/floor-plan/FloorPlanCanvas'
 import { Button } from '@/components/ui/button'
+import { AccessSummaryDialog } from '@/components/rbac/AccessInspector'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
@@ -958,6 +959,7 @@ export default function FloorAdminPage() {
   const [bulkImportOpen, setBulkImportOpen] = useState(false)
   const [pendingUploadFile, setPendingUploadFile] = useState<File | null>(null)
   const [replaceConfirmOpen, setReplaceConfirmOpen] = useState(false)
+  const [accessOpen, setAccessOpen] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const { data: floor, isLoading } = useQuery({
@@ -1060,6 +1062,9 @@ export default function FloorAdminPage() {
           <Button variant="outline" size="sm" onClick={() => setBulkImportOpen(true)}>
             <FileText className="mr-1.5 h-3.5 w-3.5" /> Bulk Import
           </Button>
+          <Button variant="outline" size="sm" onClick={() => setAccessOpen(true)}>
+            <Shield className="mr-1.5 h-3.5 w-3.5" /> Access
+          </Button>
 
           <div className="flex rounded-md border overflow-hidden">
             <Button variant={view === 'layout' ? 'secondary' : 'ghost'} size="sm"
@@ -1077,6 +1082,8 @@ export default function FloorAdminPage() {
           </div>
         </div>
       </div>
+
+      <AccessSummaryDialog kind="floor" id={floorId!} name={floor?.name ?? 'Floor'} open={accessOpen} onOpenChange={setAccessOpen} />
 
       {/* Content */}
       <div className="flex-1 overflow-hidden">

--- a/apps/web/src/pages/admin/GroupsAdminPage.tsx
+++ b/apps/web/src/pages/admin/GroupsAdminPage.tsx
@@ -96,11 +96,22 @@ function CreateGroupDialog({ open, onClose }: { open: boolean; onClose: () => vo
                 <SelectItem value="SUPER_ADMIN">Super Admin — full admin access</SelectItem>
               </SelectContent>
             </Select>
+            {globalRole === 'SUPER_ADMIN' && (
+              <p className="mt-1.5 text-xs text-destructive">
+                ⚠ Every member of this group — and anyone your identity provider maps into it — will get full org-wide admin.
+              </p>
+            )}
           </div>
         </div>
         <DialogFooter>
           <Button variant="ghost" onClick={onClose}>Cancel</Button>
-          <Button onClick={() => create.mutate()} disabled={!name.trim() || create.isPending}>
+          <Button
+            onClick={() => {
+              if (globalRole === 'SUPER_ADMIN' && !window.confirm('This group grants Super Admin to every member (and anyone the IdP maps in). Continue?')) return
+              create.mutate()
+            }}
+            disabled={!name.trim() || create.isPending}
+          >
             {create.isPending ? 'Creating…' : 'Create group'}
           </Button>
         </DialogFooter>
@@ -265,7 +276,10 @@ function GroupDetailSheet({ group, onClose }: { group: UserGroup | null; onClose
                     <Button
                       size="sm"
                       className="h-8"
-                      onClick={() => updateRole.mutate(editRole)}
+                      onClick={() => {
+                        if (editRole === 'SUPER_ADMIN' && !window.confirm('This grants Super Admin to every member of this group (and anyone the IdP maps in). Continue?')) return
+                        updateRole.mutate(editRole)
+                      }}
                       disabled={updateRole.isPending}
                     >
                       {updateRole.isPending ? 'Saving…' : 'Save'}

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -14,6 +14,7 @@ import { Separator } from '@/components/ui/separator'
 import { Badge } from '@/components/ui/badge'
 import { settingsApi, groupsApi, brandingApi, authProvidersApi, type Branding, type BrandingBanner, type LoginProvider } from '@/lib/api'
 import { EmailTemplatesCard } from '@/components/settings/EmailTemplatesCard'
+import { MappingTestPanel } from '@/components/rbac/AccessInspector'
 import { DATE_FORMAT_OPTIONS } from '@/lib/dateFormat'
 import {
   Select,
@@ -215,9 +216,11 @@ type GroupMapping = { idpGroup: string; roomerGroupId?: string; targetGlobalRole
 function GroupMappingsEditor({
   mappings,
   onChange,
+  provider,
 }: {
   mappings: GroupMapping[]
   onChange: (m: GroupMapping[]) => void
+  provider: 'OIDC' | 'SAML' | 'LDAP'
 }) {
   const { data: groups } = useQuery({
     queryKey: ['groups'],
@@ -336,6 +339,7 @@ function GroupMappingsEditor({
           })}
         </div>
       )}
+      <MappingTestPanel provider={provider} />
     </div>
   )
 }
@@ -681,7 +685,7 @@ function OidcConfigForm({
         </div>
       </div>
       <Separator />
-      <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} />
+      <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} provider="OIDC" />
       <Button size="sm" className="h-7 text-xs" disabled={saving || !issuerUrl || !clientId} onClick={handleSave}>
         {saving ? 'Saving…' : 'Save OIDC config'}
       </Button>
@@ -817,7 +821,7 @@ function SamlConfigForm({
         </div>
       </div>
       <Separator />
-      <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} />
+      <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} provider="SAML" />
       <Button size="sm" className="h-7 text-xs" disabled={saving || !entryPoint || !cert} onClick={handleSave}>
         {saving ? 'Saving…' : 'Save SAML config'}
       </Button>
@@ -1072,7 +1076,7 @@ function LdapConfigForm({
         )}
       </div>
       <Separator />
-      <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} />
+      <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} provider="LDAP" />
 
       <Separator />
 

--- a/apps/web/src/pages/admin/UsersAdminPage.tsx
+++ b/apps/web/src/pages/admin/UsersAdminPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Search, Shield, UserX, UserCheck, ChevronDown, UserPlus, Upload, KeyRound, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Search, Shield, UserX, UserCheck, ChevronDown, UserPlus, Upload, KeyRound, ChevronLeft, ChevronRight, Eye } from 'lucide-react'
 import {
   Select,
   SelectContent,
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/select'
 import { usersApi } from '@/lib/api'
 import { UserImportDialog } from '@/components/admin/UserImportDialog'
+import { EffectiveAccessDialog } from '@/components/rbac/AccessInspector'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -174,6 +175,7 @@ const statusConfig: Record<string, { label: string; variant: 'default' | 'second
 
 function UserRow({ user, onRefresh }: { user: User; onRefresh: () => void }) {
   const [resetPasswordOpen, setResetPasswordOpen] = useState(false)
+  const [accessOpen, setAccessOpen] = useState(false)
 
   const updateStatus = useMutation({
     mutationFn: (accountStatus: string) => usersApi.update(user.id, { accountStatus } as any),
@@ -206,6 +208,7 @@ function UserRow({ user, onRefresh }: { user: User; onRefresh: () => void }) {
           onClose={() => setResetPasswordOpen(false)}
         />
       )}
+      <EffectiveAccessDialog userId={user.id} userName={user.displayName} open={accessOpen} onOpenChange={setAccessOpen} />
       <Card>
         <CardContent className="p-4">
           <div className="flex items-center justify-between gap-3">
@@ -236,8 +239,17 @@ function UserRow({ user, onRefresh }: { user: User; onRefresh: () => void }) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setAccessOpen(true)}>
+                    <Eye className="mr-2 h-3.5 w-3.5" />
+                    View access
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
                   {user.globalRole !== 'SUPER_ADMIN' ? (
-                    <DropdownMenuItem onClick={() => updateRole.mutate('SUPER_ADMIN')}>
+                    <DropdownMenuItem onClick={() => {
+                      if (window.confirm(`Make ${user.displayName} a Super Administrator? This grants full, org-wide access to every building, user and setting.`)) {
+                        updateRole.mutate('SUPER_ADMIN')
+                      }
+                    }}>
                       <Shield className="mr-2 h-3.5 w-3.5" />
                       Make Administrator
                     </DropdownMenuItem>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -7,7 +7,7 @@ export type QueueEntryStatus = 'WAITING' | 'PROMOTED' | 'CLAIMED' | 'EXPIRED' | 
 export type AssetBookingStatus = 'available' | 'mine' | 'booked' | 'restricted' | 'assigned' | 'disabled' | 'queued' | 'promoted' | 'zone_conflict'
 /** @deprecated Use AssetBookingStatus instead */
 export type DeskBookingStatus = AssetBookingStatus
-export type ResourceRoleType = 'FLOOR_MANAGER' | 'BUILDING_ADMIN' | 'VIEWER' | 'USER'
+export type ResourceRoleType = 'FLOOR_MANAGER' | 'BUILDING_ADMIN'
 export type ResourceScopeType = 'FLOOR' | 'BUILDING'
 
 export interface ResourceRole {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -15,8 +15,12 @@ export enum GlobalRole {
 export enum ResourceRoleType {
   BUILDING_ADMIN = 'BUILDING_ADMIN',
   FLOOR_MANAGER = 'FLOOR_MANAGER',
-  USER = 'USER',
-  VIEWER = 'VIEWER',
+}
+
+/** Provenance of a group membership or role grant. */
+export enum RoleSource {
+  MANUAL = 'MANUAL',
+  IDP = 'IDP',
 }
 
 export enum ResourceScopeType {


### PR DESCRIPTION
## Summary

Makes the authorization model understandable and safer to operate without changing its fundamental shape. Implements all eight RBAC clarity suggestions from the review.

> **Base branch:** stacked on `fix/security-and-booking-integrity` (#163) so the diff shows only the RBAC work. Retarget to `main` once #163 merges.

## Model & data
- **Provenance** — `RoleSource (MANUAL | IDP)` on group memberships and role grants, plus `User.globalRoleSource`. Directory sync now only evicts/downgrades **IDP-sourced** grants, so it never silently undoes an admin's manual changes.
- **Last IdP groups** — record `User.lastIdpGroups` / `lastSsoLoginAt` on every SSO/LDAP login (used by the inspector and the mapping dry-run).
- **Dead roles removed** — drop the unused `VIEWER` / `USER` values from `ResourceRoleType` (enum recreated; no rows referenced them).

## Access semantics
- **Floor access is now symmetric with building access** — a floor is restricted iff a `GroupFloorAccess` rule exists, otherwise open (`canUserAccessFloor`). Removes the trap where a floor could not actually be locked down.

## New inspection APIs
- `GET /users/:id/effective-access` — every capability + where it comes from.
- `GET /buildings/:id/access-summary` and `GET /floors/:id/access-summary` — who can access / manage, with open-vs-restricted state.
- `POST /settings/auth-config/:provider/test-mapping` — dry-run IdP group → Roomer resolution; flags mappings that match nothing (likely typos / dead rules).

## Web UI
- Effective-access dialog on each user (Users admin) with provenance badges.
- Access-summary dialog + open/restricted badge on building & floor pages.
- IdP mapping dry-run panel under each provider's group-mapping editor.
- Confirmation guardrails when granting Super Admin (group create/edit and user make-admin), warning that IdP-mapped members inherit it.
- Manual vs Synced provenance pills throughout; dead VIEWER/USER role removed from the web type.

## Migration
`20260604010000_rbac_clarity` — provenance columns, `lastIdpGroups`/`lastSsoLoginAt`, and the `ResourceRoleType` enum recreation. Non-destructive (the dropped enum values were never assigned). **Applied to the dev DB.**

## Reviewer notes
- Apply with `prisma migrate deploy` (the API container's default). `migrate dev` will report the earlier `booking_no_overlap` exclusion constraint as drift because Prisma can't model `EXCLUDE` — expected.
- No automated test suite exists in the repo; validated by `tsc` build + eslint (0 errors) on `@roomer/shared`, `api`, and `web`.

## Test plan
- [x] `pnpm --filter @roomer/shared build`, `pnpm --filter api build`, `pnpm --filter web` typecheck — pass
- [x] `pnpm --filter api lint`, `pnpm --filter web lint` — 0 errors
- [x] Migration applied to dev DB; columns/enum verified
- [x] Manual: open a user's "View access" → provenance shown
- [ ] Manual: restrict a floor to a group → non-members blocked (was previously reachable)
- [ ] Manual: mapping dry-run flags an unmatched rule