### PR TITLE
feat: colleague finder / "Who's In" with desk wayfinding (#70)

### DIFF
--- a/apps/api/prisma/migrations/20260605000000_colleague_search_privacy/migration.sql
+++ b/apps/api/prisma/migrations/20260605000000_colleague_search_privacy/migration.sql
@@ -1,0 +1,2 @@
+-- Privacy opt-out for the colleague finder / "who's in" directory.
+ALTER TABLE "User" ADD COLUMN "visibleInColleagueSearch" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -433,6 +433,10 @@ model User {
   globalRoleSource        RoleSource    @default(MANUAL)
   departmentId            String?
   notificationPreferences Json          @default("{}")
+  /// When false, the user is hidden from the colleague finder / "who's in"
+  /// directory (their bookings and assigned desks are not surfaced to others).
+  /// Users can always see their own whereabouts regardless of this flag.
+  visibleInColleagueSearch Boolean      @default(true)
   /// Raw IdP group values received on the user's most recent SSO/LDAP login.
   /// Surfaced in the admin UI so admins can copy exact group identifiers when
   /// configuring mappings, and used by the mapping dry-run preview.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -28,6 +28,7 @@ import { departmentRoutes } from './routes/departments.js'
 import { subscriptionRoutes } from './routes/subscriptions.js'
 import { recurringBookingRoutes } from './routes/recurring.js'
 import { webhookRoutes } from './routes/webhooks.js'
+import { directoryRoutes } from './routes/directory.js'
 import { getBoss } from './lib/queue.js'
 import { prisma } from './lib/prisma.js'
 import { register, httpRequestDuration, setupMetrics } from './lib/metrics.js'
@@ -120,6 +121,7 @@ export async function buildApp(): Promise<FastifyInstance> {
           { name: 'Recurring Bookings', description: 'Weekly recurring booking rules and series management' },
           { name: 'Departments', description: 'Department hierarchy and user membership (admin only)' },
           { name: 'Webhooks', description: 'Webhook endpoint management and delivery log (super admin only)' },
+          { name: 'Directory', description: 'Colleague finder / "who is in" whereabouts lookup' },
         ],
         components: {
           securitySchemes: {
@@ -235,6 +237,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(scimRoutes, { prefix: '/scim/v2' })
   await fastify.register(departmentRoutes, { prefix: '/api/v1/departments' })
   await fastify.register(webhookRoutes, { prefix: '/api/v1/webhooks' })
+  await fastify.register(directoryRoutes, { prefix: '/api/v1/directory' })
 
   // ─── Health checks ─────────────────────────────────────────────────────────
   // /health/live — process is running (Kubernetes liveness probe)

--- a/apps/api/src/routes/directory.ts
+++ b/apps/api/src/routes/directory.ts
@@ -1,0 +1,182 @@
+import type { FastifyInstance } from 'fastify'
+import type { User } from '@prisma/client'
+import { prisma } from '../lib/prisma.js'
+import { GlobalRole } from '@roomer/shared'
+import { requireAuth } from '../middleware/requireAuth.js'
+import { z } from 'zod'
+
+const querySchema = z.object({
+  search: z.string().trim().max(255).optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD').optional(),
+  buildingId: z.string().min(1).optional(),
+  floorId: z.string().min(1).optional(),
+})
+
+const PER_QUERY_CAP = 500
+
+/**
+ * Building IDs the user is allowed to see occupancy for.
+ * Returns 'ALL' for super admins. For everyone else: open buildings (no access
+ * rules) plus buildings their groups can access — mirrors canUserAccessBuilding
+ * but resolved in a few set queries rather than one-per-building.
+ */
+async function accessibleBuildingIds(user: Pick<User, 'id' | 'globalRole'>): Promise<string[] | 'ALL'> {
+  if (user.globalRole === GlobalRole.SUPER_ADMIN) return 'ALL'
+
+  const [buildings, restricted, memberships] = await Promise.all([
+    prisma.building.findMany({ select: { id: true } }),
+    prisma.groupBuildingAccess.findMany({ select: { buildingId: true, groupId: true } }),
+    prisma.userGroupMember.findMany({ where: { userId: user.id }, select: { groupId: true } }),
+  ])
+
+  const userGroupIds = new Set(memberships.map((m) => m.groupId))
+  const restrictedBy = new Map<string, Set<string>>()
+  for (const r of restricted) {
+    let set = restrictedBy.get(r.buildingId)
+    if (!set) { set = new Set(); restrictedBy.set(r.buildingId, set) }
+    set.add(r.groupId)
+  }
+
+  return buildings
+    .filter((b) => {
+      const groups = restrictedBy.get(b.id)
+      if (!groups || groups.size === 0) return true // open building
+      for (const g of userGroupIds) if (groups.has(g)) return true
+      return false
+    })
+    .map((b) => b.id)
+}
+
+const assetLocationSelect = {
+  id: true,
+  name: true,
+  primaryZone: { select: { id: true, name: true } },
+  floor: { select: { id: true, name: true, building: { select: { id: true, name: true } } } },
+} as const
+
+type AssetLocation = {
+  id: string
+  name: string
+  primaryZone: { id: string; name: string } | null
+  floor: { id: string; name: string; building: { id: string; name: string } } | null
+}
+
+function locationOf(asset: AssetLocation) {
+  return {
+    assetId: asset.id,
+    assetName: asset.name,
+    zoneId: asset.primaryZone?.id ?? null,
+    zoneName: asset.primaryZone?.name ?? null,
+    floorId: asset.floor?.id ?? null,
+    floorName: asset.floor?.name ?? null,
+    buildingId: asset.floor?.building?.id ?? null,
+    buildingName: asset.floor?.building?.name ?? null,
+  }
+}
+
+export async function directoryRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Directory'], ...route.schema } })
+
+  // GET /directory/whereabouts — locate people across accessible buildings.
+  //   - no search: everyone with a CONFIRMED booking on the date ("who's in"),
+  //     plus their home desk as context.
+  //   - with search: anyone matching name/email who has a booking that day OR a
+  //     permanent desk assignment (wayfinder — works even if they didn't book).
+  fastify.get('/whereabouts', { preHandler: [requireAuth] }, async (request, reply) => {
+    const parsed = querySchema.safeParse(request.query)
+    if (!parsed.success) {
+      return reply.status(400).send({ error: { message: 'Invalid query parameters', code: 'VALIDATION_ERROR', details: parsed.error.flatten() } })
+    }
+    const search = parsed.data.search && parsed.data.search.length > 0 ? parsed.data.search : undefined
+    const dateStr = parsed.data.date ?? new Date().toISOString().slice(0, 10)
+    const dayStart = new Date(`${dateStr}T00:00:00.000Z`)
+    const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000)
+
+    const accessible = await accessibleBuildingIds(request.user)
+    if (accessible !== 'ALL' && accessible.length === 0) {
+      return reply.status(200).send({ data: [], meta: { total: 0, date: dateStr } })
+    }
+
+    // Building/floor scoping: explicit filters narrow further, but cannot widen
+    // beyond what the requester may access.
+    const buildingScope = accessible === 'ALL' ? undefined : { buildingId: { in: accessible } }
+    const floorWhere: Record<string, unknown> = { ...(buildingScope ?? {}) }
+    if (parsed.data.floorId) floorWhere.id = parsed.data.floorId
+    if (parsed.data.buildingId) {
+      if (accessible !== 'ALL' && !accessible.includes(parsed.data.buildingId)) {
+        return reply.status(403).send({ error: { message: 'Building not accessible', code: 'FORBIDDEN' } })
+      }
+      floorWhere.buildingId = parsed.data.buildingId
+    }
+    const assetWhere = { floor: Object.keys(floorWhere).length ? floorWhere : undefined }
+
+    // Visibility: opted-out users are hidden from everyone but themselves.
+    const visibility = { OR: [{ visibleInColleagueSearch: true }, { id: request.user.id }] }
+    const userWhere = search
+      ? { AND: [visibility, { OR: [
+          { displayName: { contains: search, mode: 'insensitive' as const } },
+          { email: { contains: search, mode: 'insensitive' as const } },
+        ] }] }
+      : visibility
+
+    const bookings = await prisma.booking.findMany({
+      where: {
+        status: 'CONFIRMED',
+        startsAt: { lt: dayEnd },
+        endsAt: { gt: dayStart },
+        asset: assetWhere,
+        user: userWhere,
+      },
+      select: {
+        startsAt: true, endsAt: true,
+        user: { select: { id: true, displayName: true, email: true } },
+        asset: { select: assetLocationSelect },
+      },
+      take: PER_QUERY_CAP,
+    })
+
+    const bookedUserIds = [...new Set(bookings.map((b) => b.user.id))]
+
+    // Assignments: when searching, return all matched users' home desks (even if
+    // they have no booking). Otherwise only the booked users' desks, as context.
+    const assignments = (search || bookedUserIds.length > 0)
+      ? await prisma.assetUserAssignment.findMany({
+          where: {
+            asset: assetWhere,
+            user: userWhere,
+            ...(search ? {} : { userId: { in: bookedUserIds } }),
+          },
+          select: {
+            isPrimary: true,
+            user: { select: { id: true, displayName: true, email: true } },
+            asset: { select: assetLocationSelect },
+          },
+          take: PER_QUERY_CAP,
+        })
+      : []
+
+    // Group by user
+    type Person = {
+      user: { id: string; displayName: string; email: string }
+      today: ReturnType<typeof locationOf>[]
+      assignedDesks: (ReturnType<typeof locationOf> & { isPrimary: boolean })[]
+    }
+    const people = new Map<string, Person>()
+    const ensure = (u: { id: string; displayName: string; email: string }): Person => {
+      let p = people.get(u.id)
+      if (!p) { p = { user: u, today: [], assignedDesks: [] }; people.set(u.id, p) }
+      return p
+    }
+
+    for (const b of bookings) {
+      ensure(b.user).today.push(locationOf(b.asset))
+    }
+    for (const a of assignments) {
+      ensure(a.user).assignedDesks.push({ ...locationOf(a.asset), isPrimary: a.isPrimary })
+    }
+
+    const data = [...people.values()].sort((a, b) => a.user.displayName.localeCompare(b.user.displayName))
+
+    return reply.status(200).send({ data, meta: { total: data.length, date: dateStr } })
+  })
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -30,6 +30,8 @@ const updateUserSchema = z.object({
   displayName: z.string().min(1).max(255).optional(),
   accountStatus: z.enum(['ACTIVE', 'BLOCKED']).optional(),
   globalRole: z.nativeEnum(GlobalRole).optional(),
+  // Self-serviceable privacy flag — controls visibility in the colleague finder.
+  visibleInColleagueSearch: z.boolean().optional(),
 })
 
 const notificationPrefValueSchema = z.object({
@@ -275,6 +277,7 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
           provider: true,
           accountStatus: true,
           globalRole: true,
+          visibleInColleagueSearch: true,
           createdAt: true,
           updatedAt: true,
         },

--- a/apps/web/src/components/floor-plan/DeskMarker.tsx
+++ b/apps/web/src/components/floor-plan/DeskMarker.tsx
@@ -86,6 +86,12 @@ export function DeskMarker({
   const bgClass = STATUS_BG[desk.bookingStatus] ?? 'bg-slate-400 hover:bg-slate-500 border-slate-200'
   const dotClass = STATUS_DOT[desk.bookingStatus] ?? 'bg-slate-400'
 
+  // Flip the tooltip below the desk when there isn't enough room above it within
+  // the canvas (markers near the top would otherwise render up under the toolbar).
+  // cy is the marker's screen-Y within the canvas viewport.
+  const TOOLTIP_CLEARANCE = 230
+  const tooltipSide = cy < TOOLTIP_CLEARANCE ? 'bottom' : 'top'
+
   // Scale icon size with zoom, clamped to a readable range
   const iconSize = Math.round(Math.min(Math.max(scale * 54, 42), 78))
   const fontSize = Math.round(Math.min(Math.max(scale * 13, 12), 18))
@@ -189,7 +195,7 @@ export function DeskMarker({
             </button>
           </TooltipTrigger>
 
-          <TooltipContent side="top" className="p-3 max-w-[220px]">
+          <TooltipContent side={tooltipSide} collisionPadding={8} className="p-3 max-w-[220px]">
             <div className="space-y-2">
               <p className="font-semibold text-sm">{desk.name}</p>
 

--- a/apps/web/src/components/floor-plan/DeskMarker.tsx
+++ b/apps/web/src/components/floor-plan/DeskMarker.tsx
@@ -61,6 +61,8 @@ interface DeskMarkerProps {
   stageY: number
   scale: number
   onClick: () => void
+  /** Emphasise this marker (e.g. when navigated to from the colleague finder). */
+  highlighted?: boolean
 }
 
 export function DeskMarker({
@@ -71,6 +73,7 @@ export function DeskMarker({
   stageY,
   scale,
   onClick,
+  highlighted = false,
 }: DeskMarkerProps) {
   // Convert percentage world coords → screen pixel coords
   const assetX = desk.x ?? 50
@@ -126,6 +129,13 @@ export function DeskMarker({
                   border: `3px solid ${desk.zoneColour ?? '#94a3b8'}`,
                 }}
               >
+                {/* Wayfinder highlight ring */}
+                {highlighted && (
+                  <>
+                    <span className="absolute -inset-2 rounded-full ring-4 ring-primary/70 animate-ping" />
+                    <span className="absolute -inset-2 rounded-full ring-4 ring-primary" />
+                  </>
+                )}
                 {iconUrl ? (
                   <img
                     src={iconUrl}

--- a/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
+++ b/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
@@ -49,6 +49,8 @@ interface FloorPlanCanvasProps {
   ) => void
   /** Called when the user adjusts the floor plan display scale in edit mode. */
   onDisplayScaleChange?: (scale: number) => void
+  /** Asset to emphasise (deep-linked from the colleague finder). */
+  highlightAssetId?: string
 }
 
 // ─── Hook: load a PDF URL and rasterize page 1 to HTMLImageElement ────────────
@@ -135,6 +137,7 @@ export function FloorPlanCanvas({
   onDeskClick,
   onLayoutSave,
   onDisplayScaleChange,
+  highlightAssetId,
 }: FloorPlanCanvasProps) {
   const handleAssetClick = onAssetClick ?? onDeskClick
   const containerRef = useRef<HTMLDivElement>(null)
@@ -424,6 +427,7 @@ export function FloorPlanCanvas({
               stageX={position.x}
               stageY={position.y}
               scale={scale}
+              highlighted={asset.id === highlightAssetId}
               onClick={asset.isBookable !== false ? () => handleAssetClick?.(asset) : () => {}}
             />
           ))}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   Shield,
   Layers,
+  MapPin,
 } from 'lucide-react'
 import { useState, useMemo } from 'react'
 import { cn } from '@/lib/utils'
@@ -87,6 +88,7 @@ export function Sidebar({ onNavigate }: SidebarProps) {
         {navItem('/bookings', Calendar, 'My Bookings')}
         {navItem('/queue', Clock, 'My Queue')}
         {navItem('/assets', Package, 'My Assets')}
+        {navItem('/whos-in', MapPin, "Who's In")}
 
         {/* Buildings with floor expansion */}
         <div>

--- a/apps/web/src/hooks/useNavConfig.ts
+++ b/apps/web/src/hooks/useNavConfig.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useAuthStore } from '@/stores/auth'
 import { useQuery } from '@tanstack/react-query'
 import { buildingsApi } from '@/lib/api'
-import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers, Network, Webhook } from 'lucide-react'
+import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers, Network, Webhook, MapPin } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavItem {
@@ -73,6 +73,7 @@ export function useNavConfig() {
           { to: '/bookings', icon: Calendar, label: 'My Bookings' },
           { to: '/queue', icon: Clock, label: 'My Queue' },
           { to: '/assets', icon: Package, label: 'My Assets' },
+          { to: '/whos-in', icon: MapPin, label: "Who's In" },
         ],
       },
     ]

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -805,3 +805,32 @@ export const departmentsApi = {
   removeMember: (id: string, userId: string) =>
     api.delete<{ data: { ok: true } }>(`/departments/${id}/members/${userId}`),
 }
+
+// --- Directory / colleague finder ---
+export interface WhereaboutsLocation {
+  assetId: string
+  assetName: string
+  zoneId: string | null
+  zoneName: string | null
+  floorId: string | null
+  floorName: string | null
+  buildingId: string | null
+  buildingName: string | null
+}
+export interface WhereaboutsPerson {
+  user: { id: string; displayName: string; email: string }
+  today: WhereaboutsLocation[]
+  assignedDesks: (WhereaboutsLocation & { isPrimary: boolean })[]
+}
+export const directoryApi = {
+  whereabouts: (params?: { search?: string; date?: string; buildingId?: string; floorId?: string }) => {
+    const qs = new URLSearchParams()
+    if (params?.search) qs.set('search', params.search)
+    if (params?.date) qs.set('date', params.date)
+    if (params?.buildingId) qs.set('buildingId', params.buildingId)
+    if (params?.floorId) qs.set('floorId', params.floorId)
+    return api.get<{ data: WhereaboutsPerson[]; meta: { total: number; date: string } }>(
+      `/directory/whereabouts${qs.toString() ? `?${qs}` : ''}`,
+    )
+  },
+}

--- a/apps/web/src/pages/FloorPage.tsx
+++ b/apps/web/src/pages/FloorPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useMemo } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useParams, Link, useSearchParams } from 'react-router-dom'
 import { format, addDays } from 'date-fns'
 import { ChevronLeft, ChevronRight, CalendarDays, Info, Users, Bell, BellRing } from 'lucide-react'
 import { FloorPlanCanvas } from '@/components/floor-plan/FloorPlanCanvas'
@@ -26,7 +26,14 @@ const STATUS_LEGEND: Array<{ label: string; colour: string; status: string }> = 
 
 export default function FloorPage() {
   const { floorId } = useParams<{ floorId: string }>()
-  const [selectedDate, setSelectedDate] = useState(new Date())
+  const [searchParams] = useSearchParams()
+  // Deep-link support from the colleague finder: ?date=YYYY-MM-DD&highlight=<assetId>
+  const highlightAssetId = searchParams.get('highlight') ?? undefined
+  const dateParam = searchParams.get('date')
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const d = dateParam ? new Date(`${dateParam}T00:00:00`) : new Date()
+    return Number.isNaN(d.getTime()) ? new Date() : d
+  })
   const [selectedDeskId, setSelectedDeskId] = useState<string | null>(null)
   const qc = useQueryClient()
 
@@ -43,6 +50,16 @@ export default function FloorPage() {
     () => (selectedDeskId && desks ? desks.find((d) => d.id === selectedDeskId) ?? null : null),
     [selectedDeskId, desks],
   )
+
+  // When deep-linked from the colleague finder, open the highlighted desk's panel
+  // once its data is available (one-shot, so the user can close it afterwards).
+  const [highlightApplied, setHighlightApplied] = useState(false)
+  useEffect(() => {
+    if (!highlightApplied && highlightAssetId && desks?.some((d) => d.id === highlightAssetId)) {
+      setSelectedDeskId(highlightAssetId)
+      setHighlightApplied(true)
+    }
+  }, [highlightApplied, highlightAssetId, desks])
 
   const whoIsIn = useMemo(() => {
     if (!desks) return []
@@ -187,6 +204,7 @@ export default function FloorPage() {
               floorId={floorId}
               date={selectedDate}
               onAssetClick={handleDeskClick}
+              highlightAssetId={highlightAssetId}
             />
           )}
         </div>

--- a/apps/web/src/pages/FloorPage.tsx
+++ b/apps/web/src/pages/FloorPage.tsx
@@ -56,7 +56,7 @@ export default function FloorPage() {
   const [highlightApplied, setHighlightApplied] = useState(false)
   useEffect(() => {
     if (!highlightApplied && highlightAssetId && desks?.some((d) => d.id === highlightAssetId)) {
-      setSelectedDeskId(highlightAssetId)
+      //setSelectedDeskId(highlightAssetId)
       setHighlightApplied(true)
     }
   }, [highlightApplied, highlightAssetId, desks])

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { User, Mail, Shield, Building2, Layers, Users, KeyRound, Bell, BellOff } from 'lucide-react'
+import { User, Mail, Shield, Building2, Layers, Users, KeyRound, Bell, BellOff, MapPin, EyeOff } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { usersApi } from '@/lib/api'
@@ -135,6 +135,16 @@ export default function ProfilePage() {
     onError: () => toast.error('Failed to update profile'),
   })
 
+  const updateVisibility = useMutation({
+    mutationFn: (visible: boolean) => usersApi.update(user!.id, { visibleInColleagueSearch: visible }),
+    onSuccess: (res) => {
+      setUser({ ...user!, visibleInColleagueSearch: res.data.visibleInColleagueSearch })
+      toast.success('Privacy preference saved')
+      qc.invalidateQueries({ queryKey: ['auth', 'me'] })
+    },
+    onError: () => toast.error('Failed to save preference'),
+  })
+
   const changePassword = useMutation({
     mutationFn: (data: ChangePasswordForm) =>
       usersApi.changePassword({ currentPassword: data.currentPassword, newPassword: data.newPassword }),
@@ -248,6 +258,32 @@ export default function ProfilePage() {
                 {user.accountStatus}
               </Badge>
             </div>
+          </div>
+
+          <Separator />
+
+          {/* Colleague-finder privacy */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-start gap-2">
+              <MapPin className="h-4 w-4 text-muted-foreground mt-0.5" />
+              <div>
+                <p className="text-sm font-medium">Show me in “Who's In”</p>
+                <p className="text-xs text-muted-foreground">
+                  When off, your bookings and assigned desk are hidden from the colleague finder.
+                </p>
+              </div>
+            </div>
+            <Button
+              variant={user.visibleInColleagueSearch === false ? 'outline' : 'secondary'}
+              size="sm"
+              className="shrink-0 gap-1.5"
+              disabled={updateVisibility.isPending}
+              onClick={() => updateVisibility.mutate(user.visibleInColleagueSearch === false)}
+            >
+              {user.visibleInColleagueSearch === false
+                ? <><EyeOff className="h-3.5 w-3.5" /> Hidden</>
+                : <><Users className="h-3.5 w-3.5" /> Visible</>}
+            </Button>
           </div>
 
           {/* IdP-specific info */}

--- a/apps/web/src/pages/WhosInPage.tsx
+++ b/apps/web/src/pages/WhosInPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { Search, MapPin, Home, Calendar, Users } from 'lucide-react'
+import { directoryApi, type WhereaboutsLocation, type WhereaboutsPerson } from '@/lib/api'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+
+function initialsOf(name: string) {
+  return name.split(' ').map((n) => n[0]).join('').toUpperCase().slice(0, 2)
+}
+
+function locationLabel(l: WhereaboutsLocation) {
+  return [l.assetName, l.zoneName, l.floorName, l.buildingName].filter(Boolean).join(' · ')
+}
+
+function LocationLink({ l, date, kind }: { l: WhereaboutsLocation; date: string; kind: 'today' | 'home' }) {
+  const label = locationLabel(l)
+  const Icon = kind === 'today' ? Calendar : Home
+  const inner = (
+    <span className="inline-flex items-center gap-1.5 text-sm">
+      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="text-muted-foreground">{kind === 'today' ? 'Booked' : 'Home desk'}</span>
+      <span className="font-medium">{label}</span>
+    </span>
+  )
+  // Deep-link to the floor plan with the desk highlighted (only when we know the floor).
+  return l.floorId
+    ? <Link to={`/floors/${l.floorId}?date=${date}&highlight=${l.assetId}`} className="hover:underline">{inner}</Link>
+    : inner
+}
+
+function PersonCard({ person, date }: { person: WhereaboutsPerson; date: string }) {
+  return (
+    <Card>
+      <CardContent className="flex items-start gap-3 p-4">
+        <Avatar className="h-9 w-9 shrink-0">
+          <AvatarFallback className="text-sm bg-primary/10 text-primary">{initialsOf(person.user.displayName)}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-sm">{person.user.displayName}</p>
+          <p className="text-xs text-muted-foreground truncate">{person.user.email}</p>
+          <div className="mt-2 flex flex-col gap-1.5">
+            {person.today.map((l) => (
+              <LocationLink key={`b-${l.assetId}`} l={l} date={date} kind="today" />
+            ))}
+            {person.assignedDesks.map((l) => (
+              <div key={`a-${l.assetId}`} className="flex items-center gap-2">
+                <LocationLink l={l} date={date} kind="home" />
+                {l.isPrimary && <Badge variant="outline" className="text-[10px]">primary</Badge>}
+              </div>
+            ))}
+            {person.today.length === 0 && person.assignedDesks.length === 0 && (
+              <span className="text-sm text-muted-foreground">No location today</span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function WhosInPage() {
+  const today = new Date().toISOString().slice(0, 10)
+  const [date, setDate] = useState(today)
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+
+  // Debounce the search box
+  useEffect(() => {
+    const t = setTimeout(() => setSearch(searchInput.trim()), 250)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['whereabouts', date, search],
+    queryFn: () => directoryApi.whereabouts({ date, search: search || undefined }).then((r) => r.data),
+  })
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <div className="mb-1 flex items-center gap-2">
+        <MapPin className="h-5 w-5 text-primary" />
+        <h1 className="text-2xl font-bold">Who's In</h1>
+      </div>
+      <p className="text-sm text-muted-foreground mb-5">
+        Find where colleagues are sitting — today's bookings and permanently assigned desks.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-5">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            placeholder="Search by name or email…"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+        </div>
+        <Input
+          type="date"
+          className="sm:w-44"
+          value={date}
+          onChange={(e) => setDate(e.target.value || today)}
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-20 w-full" />)}
+        </div>
+      ) : isError ? (
+        <p className="text-sm text-destructive">Could not load the directory.</p>
+      ) : !data || data.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Users className="h-10 w-10 text-muted-foreground/30 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            {search ? `No one matching “${search}” for this date.` : 'Nobody booked in for this date yet.'}
+          </p>
+          {!search && <p className="text-xs text-muted-foreground mt-1">Search by name to find someone's assigned desk too.</p>}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {data.map((p) => <PersonCard key={p.user.id} person={p} date={date} />)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -7,6 +7,7 @@ import BookingsPage from './pages/BookingsPage'
 import QueuePage from './pages/QueuePage'
 import QueueClaimPage from './pages/QueueClaimPage'
 import ProfilePage from './pages/ProfilePage'
+import WhosInPage from './pages/WhosInPage'
 import BuildingsAdminPage from './pages/admin/BuildingsAdminPage'
 import BuildingDetailAdminPage from './pages/admin/BuildingDetailAdminPage'
 import UsersAdminPage from './pages/admin/UsersAdminPage'
@@ -129,6 +130,7 @@ export function AppRouter() {
         <Route element={<Layout />}>
           <Route path="/floors/:floorId" element={<Suspense fallback={<PageLoader />}><FloorPage /></Suspense>} />
           <Route path="/bookings" element={<BookingsPage />} />
+          <Route path="/whos-in" element={<WhosInPage />} />
           <Route path="/queue" element={<QueuePage />} />
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/assets" element={<AssetsPage />} />

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -48,6 +48,7 @@ export interface User {
   accountStatus: 'ACTIVE' | 'BLOCKED'
   provider: 'LOCAL' | 'LDAP' | 'OIDC' | 'SAML'
   externalId?: string
+  visibleInColleagueSearch?: boolean
   createdAt: string
   resourceRoles?: ResourceRole[]
   groupMemberships?: UserGroupMembership[]


### PR DESCRIPTION
Closes #70.

## Summary

Adds an org-wide way to find **where colleagues sit** — covering both **today's bookings** and **permanently assigned (home) desks**, so it doubles as a wayfinder even when someone hasn't booked. Complements (does not replace) the existing per-floor "Who's in" sidebar.

## Backend
- `GET /api/v1/directory/whereabouts?search=&date=&buildingId=&floorId=` — unions today's `CONFIRMED` bookings with `AssetUserAssignment` (home desks), grouped per person with full asset → zone → floor → building location.
  - **No search:** who's in for the date (+ each person's home desk as context).
  - **With search:** wayfinder — matches name/email and surfaces a person's assigned desk even if they didn't book today.
  - Scoped to buildings the requester can access; super admins see all.
- **Privacy:** `User.visibleInColleagueSearch` (default `true`). Opted-out users are hidden from everyone but themselves. Self-serviceable via `PATCH /users/:id`.

## Web
- New searchable **"Who's In"** page (grouped, today + home desk per person), wired into the shared nav config and legacy sidebar.
- **Deep-link wayfinding:** clicking a location goes to `/floors/:id?date=&highlight=:assetId`. `FloorPage` reads the params and `DeskMarker` draws a pulsing highlight ring (threaded via `FloorPlanCanvas.highlightAssetId`). The desk side panel does **not** auto-open — highlight only.
- **Profile privacy toggle** ("Show me in Who's In").

## Also in this branch
- **Tooltip fix:** desk markers near the top of the floor plan no longer render their hover tooltip up under the toolbar — it flips below the marker when there isn't clearance above (collision padding as backstop).

## Migration
`20260605000000_colleague_search_privacy` — adds `User.visibleInColleagueSearch`. **Applied to dev DB.** Apply with `prisma migrate deploy`.

## Reviewer notes
- Reuses the existing floor-availability occupant data shape; the per-floor "Who's in" sidebar is intentionally left untouched (it's the floor-scoped complement to this org-wide view).
- Access scoping is building-level (matches how the floor view already exposes occupant names). Floor-level restriction is a finer follow-up if needed.
- No automated test suite in the repo; validated by `tsc` (api + web) + eslint (0 errors) and an authenticated smoke test of the endpoint (booking + assignment both surfaced).

## Test plan
- [x] `pnpm --filter api build`, web `tsc` — pass
- [x] `pnpm --filter api lint`, `pnpm --filter web lint` — 0 errors
- [x] Migration applied; authenticated `GET /directory/whereabouts` returns booking + home desk
- [x] Manual: search a colleague → click their desk → floor opens with desk highlighted
- [x] Manual: toggle privacy off → user disappears from others' results (still visible to self)