### PR TITLE
feat: iCal calendar invites for bookings (#69, Phase 1)

### DIFF
--- a/apps/api/src/lib/ical.ts
+++ b/apps/api/src/lib/ical.ts
@@ -1,0 +1,81 @@
+import { env } from '../env.js'
+
+export type IcalMethod = 'REQUEST' | 'CANCEL' | 'PUBLISH'
+
+/** Format a Date as an iCalendar UTC timestamp: YYYYMMDDTHHMMSSZ */
+function toIcsUtc(d: Date): string {
+  return d.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '')
+}
+
+/** Escape a text value per RFC 5545 (commas, semicolons, backslashes, newlines). */
+function escapeText(s: string): string {
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n')
+}
+
+/** Fold a content line to <=75 octets per RFC 5545 (continuation lines start with a space). */
+function foldLine(line: string): string {
+  if (line.length <= 75) return line
+  const parts: string[] = []
+  let rest = line
+  parts.push(rest.slice(0, 75))
+  rest = rest.slice(75)
+  while (rest.length > 74) {
+    parts.push(' ' + rest.slice(0, 74))
+    rest = rest.slice(74)
+  }
+  if (rest.length) parts.push(' ' + rest)
+  return parts.join('\r\n')
+}
+
+export interface BookingIcsInput {
+  id: string
+  startsAt: Date
+  endsAt: Date
+  assetName: string
+  zoneName?: string | null
+  floorName?: string | null
+  buildingName?: string | null
+}
+
+/**
+ * Build an iCalendar (.ics) document for a desk booking.
+ *  - method REQUEST  → an invite for the confirmation email
+ *  - method CANCEL   → a cancellation (same UID, bumped SEQUENCE) so the event
+ *                      is removed from the user's calendar
+ */
+export function buildBookingIcs(booking: BookingIcsInput, method: IcalMethod = 'REQUEST'): string {
+  const uid = `booking-${booking.id}@roomer`
+  const location = [booking.assetName, booking.zoneName, booking.floorName, booking.buildingName]
+    .filter(Boolean)
+    .join(', ')
+  const isCancel = method === 'CANCEL'
+  const summary = `${isCancel ? 'Cancelled: ' : ''}Desk booking — ${booking.assetName}`
+  const description = `Your Roomer desk booking for ${booking.assetName}.`
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Roomer//Desk Booking//EN',
+    'CALSCALE:GREGORIAN',
+    `METHOD:${method}`,
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `SEQUENCE:${isCancel ? 1 : 0}`,
+    `DTSTAMP:${toIcsUtc(new Date())}`,
+    `DTSTART:${toIcsUtc(booking.startsAt)}`,
+    `DTEND:${toIcsUtc(booking.endsAt)}`,
+    `SUMMARY:${escapeText(summary)}`,
+    location ? `LOCATION:${escapeText(location)}` : '',
+    `DESCRIPTION:${escapeText(description)}`,
+    `URL:${env.APP_URL}/bookings/${booking.id}`,
+    `STATUS:${isCancel ? 'CANCELLED' : 'CONFIRMED'}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter(Boolean)
+
+  return lines.map(foldLine).join('\r\n') + '\r\n'
+}

--- a/apps/api/src/lib/mailer.ts
+++ b/apps/api/src/lib/mailer.ts
@@ -25,6 +25,8 @@ interface SendEmailOptions {
   subject: string
   html: string
   text: string
+  /** Optional calendar invite/cancellation attached as a text/calendar part. */
+  icalEvent?: { method: string; filename?: string; content: string }
 }
 
 export async function sendEmail(opts: SendEmailOptions): Promise<void> {
@@ -35,6 +37,13 @@ export async function sendEmail(opts: SendEmailOptions): Promise<void> {
     subject: opts.subject,
     html: opts.html,
     text: opts.text,
+    ...(opts.icalEvent && {
+      icalEvent: {
+        method: opts.icalEvent.method,
+        filename: opts.icalEvent.filename ?? 'invite.ics',
+        content: opts.icalEvent.content,
+      },
+    }),
   })
 }
 

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -1,6 +1,7 @@
 import { PgBoss, type Job } from 'pg-boss'
 import { env } from '../env.js'
 import { prisma } from './prisma.js'
+import { buildBookingIcs } from './ical.js'
 import { sendEmail, renderBookingConfirmed, renderBookingCancelled, renderBookingReminder, renderQueueJoined, renderQueuePromoted, renderQueueExpired, renderWelcome, renderFloorAvailable, interpolateTemplate, stripHtmlToText, formatDate } from './mailer.js'
 import { randomUUID } from 'crypto'
 import { pruneExpiredBlocklistEntries } from './token-blocklist.js'
@@ -58,11 +59,12 @@ async function processSendNotification(
   let body = ''
   let emailPayload: { subject: string; html: string; text: string } | null = null
   let templateVars: Record<string, string> = {}
+  let icalEvent: { method: string; content: string } | undefined
 
   if (type === NotificationType.BOOKING_CONFIRMED && bookingId) {
     const booking = await prisma.booking.findUnique({
       where: { id: bookingId },
-      include: { asset: { include: { primaryZone: { select: { name: true } }, floor: { select: { name: true } } } } },
+      include: { asset: { include: { primaryZone: { select: { name: true } }, floor: { select: { name: true, building: { select: { name: true } } } } } } },
     })
     if (booking) {
       title = `Booking confirmed — ${booking.asset.name}`
@@ -72,6 +74,16 @@ async function processSendNotification(
         zoneName: booking.asset.primaryZone?.name ?? '',
         floorName: booking.asset.floor?.name ?? '',
       })
+      icalEvent = {
+        method: 'REQUEST',
+        content: buildBookingIcs({
+          id: booking.id, startsAt: booking.startsAt, endsAt: booking.endsAt,
+          assetName: booking.asset.name,
+          zoneName: booking.asset.primaryZone?.name,
+          floorName: booking.asset.floor?.name,
+          buildingName: booking.asset.floor?.building?.name,
+        }, 'REQUEST'),
+      }
       templateVars = {
         userName: user.displayName, userEmail: user.email,
         assetName: booking.asset.name,
@@ -92,6 +104,13 @@ async function processSendNotification(
       title = `Booking cancelled — ${booking.asset.name}`
       body = `Your booking for ${booking.asset.name} has been cancelled.`
       emailPayload = renderBookingCancelled(booking, user, booking.asset)
+      icalEvent = {
+        method: 'CANCEL',
+        content: buildBookingIcs({
+          id: booking.id, startsAt: booking.startsAt, endsAt: booking.endsAt,
+          assetName: booking.asset.name,
+        }, 'CANCEL'),
+      }
       templateVars = {
         userName: user.displayName, userEmail: user.email,
         assetName: booking.asset.name,
@@ -108,6 +127,13 @@ async function processSendNotification(
       title = `Booking cancelled by admin — ${booking.asset.name}`
       body = `Your booking for ${booking.asset.name} has been cancelled by an administrator.`
       emailPayload = renderBookingCancelled(booking, user, booking.asset)
+      icalEvent = {
+        method: 'CANCEL',
+        content: buildBookingIcs({
+          id: booking.id, startsAt: booking.startsAt, endsAt: booking.endsAt,
+          assetName: booking.asset.name,
+        }, 'CANCEL'),
+      }
       templateVars = {
         userName: user.displayName, userEmail: user.email,
         assetName: booking.asset.name,
@@ -260,7 +286,7 @@ async function processSendNotification(
   // Send email if we have a template and user hasn't opted out
   if (sendEmailNotif && emailPayload) {
     try {
-      await sendEmail({ to: user.email, ...emailPayload })
+      await sendEmail({ to: user.email, ...emailPayload, ...(icalEvent && { icalEvent }) })
     } catch (err) {
       process.stderr.write(JSON.stringify({ level: 'error', msg: '[queue] Failed to send email', to: user.email, err: String(err) }) + '\n')
       // Don't re-throw — notification is persisted, email failure is non-fatal

--- a/apps/api/src/routes/bookings.ts
+++ b/apps/api/src/routes/bookings.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '../middleware/requireAuth.js'
 import { isFloorManagerForFloor, getManagedBuildingIds } from '../middleware/requireRole.js'
 import { enqueueNotification, fanOutFloorAvailable, CLAIM_DEADLINE_MS } from '../lib/queue.js'
 import { dispatchWebhook } from '../lib/webhook.js'
+import { buildBookingIcs } from '../lib/ical.js'
 import { randomUUID } from 'crypto'
 import { checkGroupAccess } from './groups.js'
 import { assertBookable, hasConfirmedOverlap, lockAssetForBooking, isOverlapConstraintViolation } from '../lib/booking.js'
@@ -282,6 +283,42 @@ export async function bookingRoutes(fastify: FastifyInstance): Promise<void> {
     }
 
     return reply.status(200).send({ data: booking })
+  })
+
+  // GET /bookings/:id/calendar.ics — download an iCalendar invite for the booking
+  fastify.get('/:id/calendar.ics', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const booking = await prisma.booking.findUnique({
+      where: { id },
+      include: {
+        asset: {
+          include: {
+            floor: { select: { name: true, building: { select: { name: true } } } },
+            primaryZone: { select: { name: true } },
+          },
+        },
+      },
+    })
+    if (!booking) {
+      return reply.status(404).send({ error: { message: 'Booking not found', code: 'NOT_FOUND' } })
+    }
+    if (booking.userId !== request.user.id && request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
+    }
+
+    const method = booking.status === 'CANCELLED' ? 'CANCEL' : 'PUBLISH'
+    const ics = buildBookingIcs({
+      id: booking.id, startsAt: booking.startsAt, endsAt: booking.endsAt,
+      assetName: booking.asset.name,
+      zoneName: booking.asset.primaryZone?.name,
+      floorName: booking.asset.floor?.name,
+      buildingName: booking.asset.floor?.building?.name,
+    }, method)
+
+    return reply
+      .header('Content-Type', 'text/calendar; charset=utf-8')
+      .header('Content-Disposition', `attachment; filename="booking-${booking.id}.ics"`)
+      .send(ics)
   })
 
   // PATCH /bookings/:id — modify booking

--- a/apps/web/src/pages/BookingsPage.tsx
+++ b/apps/web/src/pages/BookingsPage.tsx
@@ -401,6 +401,14 @@ function BookingRow({ booking, showCancel }: { booking: Booking; showCancel: boo
 
             {canModify && (
               <div className="flex items-center gap-1 shrink-0">
+                <a
+                  href={`/api/v1/bookings/${booking.id}/calendar.ics`}
+                  download
+                  title="Add to calendar"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent"
+                >
+                  <CalendarPlus className="h-4 w-4" />
+                </a>
                 <Button
                   variant="ghost"
                   size="icon"


### PR DESCRIPTION
Implements #69 Phase 1 — the calendar-integration quick win. Clean diff against `main` (rebased after #167 merged).

## Summary
Booking emails now carry calendar invites, plus a download link, so a desk booking lands on the user's calendar.

- **`lib/ical.ts`** — builds RFC 5545 `.ics` documents (CRLF, escaped text, 75-octet line folding) with a stable `UID` (`booking-<id>@roomer`) so updates/cancellations reconcile to the same calendar event.
- **Emails:** confirmation → `METHOD:REQUEST` invite; cancellation (user + admin) → `METHOD:CANCEL` so the event is removed. `sendEmail()` gained an optional `icalEvent` part (nodemailer).
- **Download:** `GET /bookings/:id/calendar.ics` (owner/admin) — `METHOD:PUBLISH`, or `CANCEL` for a cancelled booking.
- **Web:** "Add to calendar" link on upcoming confirmed bookings.

## Notes
- No schema change; no auth/booking-path changes — additive output in the email flow + one read endpoint.
- **Phase 2** (two-way Outlook/Google sync) intentionally out of scope — recommend a separate issue.

## Test plan
- [x] `pnpm --filter api build`, web `tsc`, `pnpm --filter api lint` — clean
- [x] Authenticated `GET /bookings/:id/calendar.ics` returns a valid VCALENDAR (stable UID, LOCATION, correct METHOD)
- [ ] Manual: create a booking → confirmation email invite adds to a calendar
- [ ] Manual: cancel → email removes the event