### PR TITLE
feat(auth): OIDC department attribute mapping (#147)

### DIFF
--- a/apps/api/src/lib/oidc.ts
+++ b/apps/api/src/lib/oidc.ts
@@ -11,6 +11,8 @@ export interface OidcConfig {
   label?: string
   /** JWT/userinfo claim name containing the user's groups (default: groups) */
   groupsClaimName?: string
+  /** Userinfo claim name to map to the user's Roomer department. Blank = disabled. */
+  departmentClaimName?: string
   groupMappings?: GroupMapping[]
 }
 

--- a/apps/api/src/routes/auth-enterprise.ts
+++ b/apps/api/src/routes/auth-enterprise.ts
@@ -178,6 +178,24 @@ export async function enterpriseAuthRoutes(fastify: FastifyInstance): Promise<vo
         await applyGroupMappings(user.id, idpGroups, cfg.groupMappings, true)
       }
 
+      // Department mapping — opt-in via a configured claim name (blank = disabled).
+      // Mirrors the SAML/LDAP department-attribute behaviour.
+      if (cfg.departmentClaimName) {
+        const rawDept = (userinfo as Record<string, unknown>)[cfg.departmentClaimName]
+        const deptName = typeof rawDept === 'string' ? rawDept.trim() : undefined
+        if (deptName) {
+          const org = await prisma.organisation.findFirst({ select: { id: true } })
+          if (org) {
+            const dept = await prisma.department.upsert({
+              where: { organisationId_name: { organisationId: org.id, name: deptName } },
+              create: { organisationId: org.id, name: deptName },
+              update: {},
+            })
+            await prisma.user.update({ where: { id: user.id }, data: { departmentId: dept.id } })
+          }
+        }
+      }
+
       // Issue JWT cookie — OIDC session state is no longer needed
       issueSsoToken(reply, user)
     } catch (err) {

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -72,6 +72,7 @@ const oidcConfigSchema = z.object({
   scope: z.string().optional(),
   label: z.string().optional(),
   groupsClaimName: z.string().optional(),
+  departmentClaimName: z.string().optional(),
   groupMappings: z.array(groupMappingSchema).optional(),
 })
 

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -634,13 +634,14 @@ function OidcConfigForm({
   const [scope, setScope] = useState((current.scope as string) ?? 'openid profile email groups')
   const [label, setLabel] = useState((current.label as string) ?? 'Sign in with SSO')
   const [groupsClaimName, setGroupsClaimName] = useState((current.groupsClaimName as string) ?? 'groups')
+  const [departmentClaimName, setDepartmentClaimName] = useState((current.departmentClaimName as string) ?? '')
   const [groupMappings, setGroupMappings] = useState<GroupMapping[]>(
     (current.groupMappings as GroupMapping[]) ?? [],
   )
 
   function handleSave() {
     const cfg: Record<string, unknown> = {
-      issuerUrl, clientId, redirectUri, scope, label, groupsClaimName, groupMappings,
+      issuerUrl, clientId, redirectUri, scope, label, groupsClaimName, departmentClaimName, groupMappings,
     }
     if (clientSecret) cfg.clientSecret = clientSecret
     onSave(cfg)
@@ -682,6 +683,11 @@ function OidcConfigForm({
           <Label className="text-xs">Groups claim name</Label>
           <Input value={groupsClaimName} onChange={(e) => setGroupsClaimName(e.target.value)}
             className="mt-1 h-8 text-sm" placeholder="groups" />
+        </div>
+        <div>
+          <Label className="text-xs">Department claim name <span className="text-muted-foreground font-normal">(optional)</span></Label>
+          <Input value={departmentClaimName} onChange={(e) => setDepartmentClaimName(e.target.value)}
+            className="mt-1 h-8 text-sm" placeholder="department" />
         </div>
       </div>
       <Separator />


### PR DESCRIPTION
Closes #147. Brings OIDC to parity with SAML/LDAP, which already map a directory attribute to a Roomer department on login.

## Changes
- `OidcConfig` gains `departmentClaimName` (optional — blank disables department sync, no breaking change).
- OIDC callback (`/auth/oidc/callback`) extracts the claim, upserts the `Department`, and sets `user.departmentId` — mirroring the existing SAML department block.
- Settings UI: "Department claim name" input alongside the Groups claim name input on the OIDC form.

## Notes
- No schema change.
- Matches the pattern in `lib/saml.ts` → `extractDepartmentFromProfile()` and the SAML callback.

## Test plan
- [x] `pnpm --filter api build`, web `tsc`, `pnpm --filter api lint` — clean
- [ ] Manual: set a Department claim name, log in via OIDC with that claim → user's department is set
- [ ] Manual: leave it blank → no department sync (unchanged behaviour)