### PR TITLE
feat: amenity filtering on the floor plan (#75)

### DIFF
--- a/apps/api/src/routes/floors.ts
+++ b/apps/api/src/routes/floors.ts
@@ -531,13 +531,21 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
   // Returns zones with nested bookable assets and computed bookingStatus for the requesting user.
   fastify.get('/:id/availability', { preHandler: [requireAuth] }, async (request, reply) => {
     const { id } = request.params as { id: string }
-    const queryResult = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) }).safeParse(request.query)
+    const queryResult = z.object({
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      // Optional comma-separated amenity filter, e.g. ?amenities=monitor,standing.
+      // Returns only assets that have ALL listed amenities.
+      amenities: z.string().optional(),
+    }).safeParse(request.query)
     if (!queryResult.success || !queryResult.data.date) {
       return reply.status(400).send({
         error: { message: 'date query param required (YYYY-MM-DD)', code: 'INVALID_DATE' },
       })
     }
     const { date } = queryResult.data
+    const amenityFilter = queryResult.data.amenities
+      ? queryResult.data.amenities.split(',').map((s) => s.trim()).filter(Boolean)
+      : []
 
     const currentUserId = request.user.id
     const dayStart = new Date(`${date}T00:00:00.000Z`)
@@ -550,7 +558,7 @@ export async function floorRoutes(fastify: FastifyInstance): Promise<void> {
           orderBy: { name: 'asc' },
           include: {
             assets: {
-              where: { isBookable: true },
+              where: { isBookable: true, ...(amenityFilter.length ? { amenities: { hasEvery: amenityFilter } } : {}) },
               orderBy: { name: 'asc' },
               include: {
                 category: { select: { id: true, name: true, defaultIcon: true, colour: true, iconUrl: true } },

--- a/apps/web/src/components/floor-plan/DeskMarker.tsx
+++ b/apps/web/src/components/floor-plan/DeskMarker.tsx
@@ -63,6 +63,8 @@ interface DeskMarkerProps {
   onClick: () => void
   /** Emphasise this marker (e.g. when navigated to from the colleague finder). */
   highlighted?: boolean
+  /** Fade this marker back when it doesn't match the active amenity filter. */
+  dimmed?: boolean
 }
 
 export function DeskMarker({
@@ -74,6 +76,7 @@ export function DeskMarker({
   scale,
   onClick,
   highlighted = false,
+  dimmed = false,
 }: DeskMarkerProps) {
   // Convert percentage world coords → screen pixel coords
   const assetX = desk.x ?? 50
@@ -104,12 +107,13 @@ export function DeskMarker({
 
   return (
     <div
-      className="absolute"
+      className="absolute transition-opacity"
       style={{
         left: cx,
         top: cy,
         transform: 'translate(-50%, -50%)',
         pointerEvents: 'auto',
+        opacity: dimmed ? 0.25 : 1,
       }}
     >
       <TooltipProvider delayDuration={150}>

--- a/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
+++ b/apps/web/src/components/floor-plan/FloorPlanCanvas.tsx
@@ -51,6 +51,8 @@ interface FloorPlanCanvasProps {
   onDisplayScaleChange?: (scale: number) => void
   /** Asset to emphasise (deep-linked from the colleague finder). */
   highlightAssetId?: string
+  /** Assets to fade back because they don't match the active amenity filter. */
+  dimmedAssetIds?: Set<string>
 }
 
 // ─── Hook: load a PDF URL and rasterize page 1 to HTMLImageElement ────────────
@@ -138,6 +140,7 @@ export function FloorPlanCanvas({
   onLayoutSave,
   onDisplayScaleChange,
   highlightAssetId,
+  dimmedAssetIds,
 }: FloorPlanCanvasProps) {
   const handleAssetClick = onAssetClick ?? onDeskClick
   const containerRef = useRef<HTMLDivElement>(null)
@@ -428,6 +431,7 @@ export function FloorPlanCanvas({
               stageY={position.y}
               scale={scale}
               highlighted={asset.id === highlightAssetId}
+              dimmed={dimmedAssetIds?.has(asset.id) ?? false}
               onClick={asset.isBookable !== false ? () => handleAssetClick?.(asset) : () => {}}
             />
           ))}

--- a/apps/web/src/pages/FloorPage.tsx
+++ b/apps/web/src/pages/FloorPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback, useMemo, useEffect } from 'react'
 import { useParams, Link, useSearchParams } from 'react-router-dom'
 import { format, addDays } from 'date-fns'
-import { ChevronLeft, ChevronRight, CalendarDays, Info, Users, Bell, BellRing } from 'lucide-react'
+import { ChevronLeft, ChevronRight, CalendarDays, Info, Users, Bell, BellRing, SlidersHorizontal } from 'lucide-react'
 import { FloorPlanCanvas } from '@/components/floor-plan/FloorPlanCanvas'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { DeskPanel } from '@/components/floor-plan/DeskPanel'
 import { FloorSubscribeDialog } from '@/components/floor-plan/FloorSubscribeDialog'
 import { useFloorData, useFloorAvailability } from '@/hooks/useFloor'
@@ -79,6 +80,34 @@ export default function FloorPage() {
     return Array.from(seen.values()).sort((a, b) => a.displayName.localeCompare(b.displayName))
   }, [desks])
 
+  // ─── Amenity filter ─────────────────────────────────────────────────────────
+  const [selectedAmenities, setSelectedAmenities] = useState<Set<string>>(new Set())
+
+  const availableAmenities = useMemo(() => {
+    const set = new Set<string>()
+    for (const d of desks ?? []) for (const a of d.amenities ?? []) set.add(a)
+    return [...set].sort((a, b) => a.localeCompare(b))
+  }, [desks])
+
+  // Desks that do NOT have every selected amenity are faded back.
+  const dimmedAssetIds = useMemo(() => {
+    if (selectedAmenities.size === 0) return undefined
+    const ids = new Set<string>()
+    for (const d of desks ?? []) {
+      const has = new Set(d.amenities ?? [])
+      if (![...selectedAmenities].every((a) => has.has(a))) ids.add(d.id)
+    }
+    return ids
+  }, [desks, selectedAmenities])
+
+  const toggleAmenity = (a: string) =>
+    setSelectedAmenities((prev) => {
+      const next = new Set(prev)
+      if (next.has(a)) next.delete(a)
+      else next.add(a)
+      return next
+    })
+
   const handlePrevDay = () => setSelectedDate((d) => addDays(d, -1))
   const handleNextDay = () => setSelectedDate((d) => addDays(d, 1))
 
@@ -154,6 +183,35 @@ export default function FloorPage() {
             </div>
           ))}
           <div className="ml-2 border-l pl-3 flex items-center gap-1">
+            {availableAmenities.length > 0 && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant={selectedAmenities.size > 0 ? 'secondary' : 'ghost'} size="sm" className="h-7 gap-1.5 text-xs">
+                    <SlidersHorizontal className="h-3.5 w-3.5" />
+                    Amenities
+                    {selectedAmenities.size > 0 && (
+                      <Badge variant="secondary" className="ml-0.5 h-4 rounded-full px-1.5 text-xs">{selectedAmenities.size}</Badge>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-56 p-2">
+                  <div className="flex items-center justify-between px-1 pb-1.5">
+                    <span className="text-xs font-medium">Filter by amenity</span>
+                    {selectedAmenities.size > 0 && (
+                      <button className="text-xs text-muted-foreground hover:text-foreground" onClick={() => setSelectedAmenities(new Set())}>Clear</button>
+                    )}
+                  </div>
+                  <div className="max-h-64 overflow-y-auto">
+                    {availableAmenities.map((a) => (
+                      <label key={a} className="flex items-center gap-2 rounded px-1.5 py-1 text-sm hover:bg-accent cursor-pointer">
+                        <input type="checkbox" checked={selectedAmenities.has(a)} onChange={() => toggleAmenity(a)} className="h-3.5 w-3.5" />
+                        <span className="capitalize">{a}</span>
+                      </label>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
             <Button
               variant={showWhoIsIn ? 'secondary' : 'ghost'}
               size="sm"
@@ -205,6 +263,7 @@ export default function FloorPage() {
               date={selectedDate}
               onAssetClick={handleDeskClick}
               highlightAssetId={highlightAssetId}
+              dimmedAssetIds={dimmedAssetIds}
             />
           )}
         </div>


### PR DESCRIPTION
Closes #75. The `Asset.amenities` field already existed but had no filtering UI or API.

## Changes
- **API:** `GET /floors/:id/availability?amenities=monitor,standing` — returns only assets that have **all** listed amenities (Prisma `hasEvery`). Serves the documented search/BI use case.
- **Floor plan UI:** an "Amenities" filter popover in the toolbar that lists the distinct amenities present on the floor. Selecting amenities **dims the desks that don't match** (keeping the layout intact rather than removing markers and leaving gaps). Client-side, no refetch — amenities are already returned per asset. Threaded via `FloorPlanCanvas.dimmedAssetIds` → `DeskMarker.dimmed`.

## Notes
- No schema change.
- The optional standardised amenity **taxonomy** (admin-defined vocabulary) from the issue is left as a follow-up; this ships the filter against the existing freeform `amenities[]`.

## Test plan
- [x] `pnpm --filter api build`, web `tsc`, `pnpm --filter web lint` — clean
- [x] `?amenities=` filter returns only matching assets (verified: non-matching value → empty asset lists)
- [ ] Manual: tag desks with amenities → filter popover dims non-matching desks