### PR TITLE
feat(analytics): no-show rate KPI (#71/#84)

### DIFF
--- a/apps/api/prisma/migrations/20260606010000_booking_noshow_flag/migration.sql
+++ b/apps/api/prisma/migrations/20260606010000_booking_noshow_flag/migration.sql
@@ -1,0 +1,2 @@
+-- Distinguish no-show releases from manual cancellations for analytics.
+ALTER TABLE "Booking" ADD COLUMN "noShow" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -569,6 +569,9 @@ model Booking {
   /// When the booker confirmed they are physically present. Null = not checked
   /// in; the no-show release job cancels un-checked-in bookings past the grace.
   checkedInAt       DateTime?
+  /// True when this booking was CANCELLED by the no-show release job (vs a manual
+  /// cancellation). Lets analytics separate no-show rate from cancellation rate.
+  noShow            Boolean              @default(false)
   recurringRuleId   String?
   createdAt         DateTime             @default(now())
   updatedAt         DateTime             @updatedAt

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -408,7 +408,7 @@ async function handleReleaseNoShows(): Promise<void> {
 
   await prisma.booking.updateMany({
     where: { id: { in: noShows.map((b) => b.id) } },
-    data: { status: 'CANCELLED' },
+    data: { status: 'CANCELLED', noShow: true },
   })
 
   await getBoss().insert(

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -269,9 +269,10 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
 
       const bookingWhere: Record<string, unknown> = { startsAt: { gte: startDate, lte: endDate }, ...bookingBuildingFilter }
 
-      const [confirmed, cancelled, completed, uniqueBookers, bookableDesks, assignedDesks, disabledDesks, queueDepth] = await Promise.all([
+      const [confirmed, cancelled, noShowCount, completed, uniqueBookers, bookableDesks, assignedDesks, disabledDesks, queueDepth] = await Promise.all([
         prisma.booking.count({ where: { ...bookingWhere, status: 'CONFIRMED' } }),
         prisma.booking.count({ where: { ...bookingWhere, status: 'CANCELLED' } }),
+        prisma.booking.count({ where: { ...bookingWhere, status: 'CANCELLED', noShow: true } }),
         prisma.booking.count({ where: { ...bookingWhere, status: 'COMPLETED' } }),
         prisma.booking.findMany({
           where: { ...bookingWhere, status: { in: ['CONFIRMED', 'COMPLETED'] } },
@@ -287,7 +288,10 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
 
       const totalDesks = bookableDesks + assignedDesks + disabledDesks
       const totalAttempted = confirmed + cancelled + completed
-      const cancellationRate = totalAttempted > 0 ? Math.round((cancelled / totalAttempted) * 100) : 0
+      // "cancelled" includes no-show releases — separate them so each rate is distinct.
+      const manualCancelled = Math.max(0, cancelled - noShowCount)
+      const cancellationRate = totalAttempted > 0 ? Math.round((manualCancelled / totalAttempted) * 100) : 0
+      const noShowRate = totalAttempted > 0 ? Math.round((noShowCount / totalAttempted) * 100) : 0
       // Capacity = all non-disabled desks (OPEN + RESTRICTED + ASSIGNED); disabled are truly out of service
       const activeDesks = bookableDesks + assignedDesks
       const totalCapacity = activeDesks * workingDays
@@ -296,9 +300,11 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.status(200).send({
         data: {
           totalBookings: confirmed,
-          cancelledBookings: cancelled,
+          cancelledBookings: manualCancelled,
           completedBookings: completed,
           cancellationRate,
+          noShowBookings: noShowCount,
+          noShowRate,
           uniqueBookers: uniqueBookers.length,
           avgDailyBookings: Math.round((confirmed / workingDays) * 10) / 10,
           totalDesks,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -648,7 +648,8 @@ export type AnalyticsParams = { startDate?: string; endDate?: string; buildingId
 
 export type SummaryStats = {
   totalBookings: number; cancelledBookings: number; completedBookings: number
-  cancellationRate: number; uniqueBookers: number; avgDailyBookings: number
+  cancellationRate: number; noShowBookings: number; noShowRate: number
+  uniqueBookers: number; avgDailyBookings: number
   totalDesks: number; bookableDesks: number; assignedDesks: number; disabledDesks: number
   overallUtilisationPct: number; queueDepth: number; workingDays: number
 }

--- a/apps/web/src/pages/admin/ReportsAdminPage.tsx
+++ b/apps/web/src/pages/admin/ReportsAdminPage.tsx
@@ -19,7 +19,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
   Download, Users,
-  BarChart3, Clock, CheckCircle2, XCircle, Layers, UserCheck,
+  BarChart3, Clock, CheckCircle2, XCircle, Layers, UserCheck, UserX,
 } from 'lucide-react'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -121,14 +121,16 @@ function SummaryCards({ params }: { params: AnalyticsParams }) {
   })
 
   const cancellationColour = !data ? 'default' : data.cancellationRate > 20 ? 'red' : data.cancellationRate > 10 ? 'amber' : 'green'
+  const noShowColour = !data ? 'default' : data.noShowRate > 15 ? 'red' : data.noShowRate > 5 ? 'amber' : 'green'
   const utilisationColour = !data ? 'default' : data.overallUtilisationPct > 70 ? 'green' : data.overallUtilisationPct > 40 ? 'default' : 'amber'
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-7 gap-4">
+    <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-8 gap-4">
       <KpiCard label="Confirmed Bookings" value={data?.totalBookings ?? '—'} sub={`over ${data?.workingDays ?? '…'} working days`} icon={CheckCircle2} loading={isLoading} colour="green" />
       <KpiCard label="Avg / Day" value={data?.avgDailyBookings ?? '—'} sub="confirmed bookings" icon={BarChart3} loading={isLoading} />
       <KpiCard label="Unique Bookers" value={data?.uniqueBookers ?? '—'} sub="distinct users" icon={Users} loading={isLoading} />
       <KpiCard label="Cancellation Rate" value={data ? `${data.cancellationRate}%` : '—'} sub={`${data?.cancelledBookings ?? '…'} cancelled`} icon={XCircle} loading={isLoading} colour={cancellationColour} />
+      <KpiCard label="No-show Rate" value={data ? `${data.noShowRate}%` : '—'} sub={`${data?.noShowBookings ?? '…'} released`} icon={UserX} loading={isLoading} colour={noShowColour} />
       <KpiCard label="Desk Utilisation" value={data ? `${data.overallUtilisationPct}%` : '—'} sub={`${data?.bookableDesks ?? '…'} bookable desks`} icon={Layers} loading={isLoading} colour={utilisationColour} />
       <KpiCard label="Assigned Desks" value={data?.assignedDesks ?? '—'} sub={`${data?.disabledDesks ?? '…'} disabled`} icon={UserCheck} loading={isLoading} colour="default" />
       <KpiCard label="Queue Depth" value={data?.queueDepth ?? '—'} sub="currently waiting" icon={Clock} loading={isLoading} colour={data?.queueDepth && data.queueDepth > 10 ? 'amber' : 'default'} />
@@ -569,6 +571,8 @@ function ExportAllButton({ params, days }: { params: AnalyticsParams; days: Pres
       sections.push(['Total Confirmed Bookings', String(summary.totalBookings)])
       sections.push(['Cancelled Bookings', String(summary.cancelledBookings)])
       sections.push(['Cancellation Rate', `${summary.cancellationRate}%`])
+      sections.push(['No-show Bookings', String(summary.noShowBookings)])
+      sections.push(['No-show Rate', `${summary.noShowRate}%`])
       sections.push(['Unique Bookers', String(summary.uniqueBookers)])
       sections.push(['Avg Daily Bookings', String(summary.avgDailyBookings)])
       sections.push(['Total Desks', String(summary.totalDesks)])


### PR DESCRIPTION
Adds the no-show-rate analytics KPI on top of check-in/no-show (#71).

**Base:** stacked on `feat/checkin-noshow` (#171) so the diff shows only the analytics work — retarget to `main` after #171 merges (or merge #171 first).

## Changes
- **`Booking.noShow`** flag, set by the release worker, so analytics can distinguish a no-show release from a manual cancellation (both end up `CANCELLED`).
- **`/analytics/summary`** returns `noShowBookings` + `noShowRate`; the existing `cancellationRate`/`cancelledBookings` now **exclude** no-shows, so each rate is distinct and accurate.
- **Reports page:** a "No-show Rate" KPI card (green/amber/red thresholds) and the CSV export includes No-show Bookings + Rate.

## Notes
- No-show rate = noShowReleased / (confirmed + cancelled + completed) over the selected range.
- Migration `20260606010000_booking_noshow_flag` (applied to dev DB; `prisma migrate deploy`).

## Test plan
- [x] api build, web tsc, web lint — clean (0 errors)
- [x] Migration applied; `/analytics/summary` returns `noShowBookings`/`noShowRate`
- [ ] Manual: trigger a no-show release → No-show Rate card + CSV reflect it, cancellation rate unaffected