### PR TITLE
feat(settings): UI-configurable SMTP, overridden by env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ All API environment variables. Every variable accepts a `ROOMER_` prefix (e.g. `
 | `SMTP_USER` | — | SMTP username (if required) |
 | `SMTP_PASS` | — | SMTP password (if required) |
 | `EMAIL_FROM` | `noreply@roomer.local` | Sender address for system emails |
+
+> Email/SMTP can also be configured in the admin UI (**Settings → Email**). Any of the `SMTP_*` / `EMAIL_FROM` variables above, when set, **override** the UI value at runtime (captured at startup) and appear locked in the form.
 | `APP_URL` | `http://localhost:5173` | Public URL used in email links |
 
 ---

--- a/apps/api/prisma/migrations/20260607000000_org_email_config/migration.sql
+++ b/apps/api/prisma/migrations/20260607000000_org_email_config/migration.sql
@@ -1,0 +1,2 @@
+-- UI-configurable SMTP/email settings (env vars still override at runtime).
+ALTER TABLE "Organisation" ADD COLUMN "emailConfig" JSONB NOT NULL DEFAULT '{}';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -132,6 +132,10 @@ model Organisation {
   queueClaimWindowHours       Int          @default(4)
   dateFormat                  String       @default("dd/MM/yyyy")
   emailTemplates              Json         @default("{}")
+  /// SMTP/email settings configurable from the admin UI: { host, port, secure,
+  /// user, from, password(enc:v1:...) }. Matching SMTP_* env vars override these
+  /// at runtime (env wins, captured at startup).
+  emailConfig                 Json         @default("{}")
   branding                    Json         @default("{}")
   bookingReminderHours        Int          @default(24)
   maxRecurringBookingWeeks    Int          @default(12)

--- a/apps/api/src/lib/mailer.ts
+++ b/apps/api/src/lib/mailer.ts
@@ -1,23 +1,30 @@
 import nodemailer from 'nodemailer'
 import type { Transporter } from 'nodemailer'
 import { env } from '../env.js'
+import { getEffectiveSmtp } from './smtp-config.js'
 import type { Booking, User, Asset, QueueEntry } from '@roomer/shared'
 
 let transporter: Transporter | null = null
+let cachedFrom: string | null = null
 
-function getTransporter(): Transporter {
+async function getTransporter(): Promise<{ transporter: Transporter; from: string }> {
   if (!transporter) {
+    const cfg = await getEffectiveSmtp()
     transporter = nodemailer.createTransport({
-      host: env.SMTP_HOST,
-      port: env.SMTP_PORT,
-      secure: env.SMTP_SECURE,
-      auth:
-        env.SMTP_USER && env.SMTP_PASS
-          ? { user: env.SMTP_USER, pass: env.SMTP_PASS }
-          : undefined,
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.secure,
+      auth: cfg.user && cfg.pass ? { user: cfg.user, pass: cfg.pass } : undefined,
     })
+    cachedFrom = cfg.from
   }
-  return transporter
+  return { transporter, from: cachedFrom ?? 'noreply@roomer.local' }
+}
+
+/** Drop the cached transporter so the next send re-resolves config (call after a settings change). */
+export function resetMailer(): void {
+  transporter = null
+  cachedFrom = null
 }
 
 interface SendEmailOptions {
@@ -30,9 +37,9 @@ interface SendEmailOptions {
 }
 
 export async function sendEmail(opts: SendEmailOptions): Promise<void> {
-  const t = getTransporter()
+  const { transporter: t, from } = await getTransporter()
   await t.sendMail({
-    from: env.EMAIL_FROM,
+    from,
     to: opts.to,
     subject: opts.subject,
     html: opts.html,

--- a/apps/api/src/lib/smtp-config.ts
+++ b/apps/api/src/lib/smtp-config.ts
@@ -1,0 +1,81 @@
+import { prisma } from './prisma.js'
+import { decryptStringMaybe } from './encryption.js'
+
+// ── Startup env snapshot ──────────────────────────────────────────────────────
+// Read the raw SMTP env vars ONCE at startup. A value being present (even empty)
+// means the operator set it via the environment, so it overrides the UI/DB value.
+// (We read process.env directly rather than the parsed `env` object, because that
+// object applies defaults and would hide whether a var was actually set.)
+function rawEnv(name: string): string | undefined {
+  return process.env[`ROOMER_${name}`] ?? process.env[name]
+}
+
+const ENV = {
+  host: rawEnv('SMTP_HOST'),
+  port: rawEnv('SMTP_PORT'),
+  secure: rawEnv('SMTP_SECURE'),
+  user: rawEnv('SMTP_USER'),
+  pass: rawEnv('SMTP_PASS'),
+  from: rawEnv('EMAIL_FROM'),
+} as const
+
+/** Which fields are pinned by an environment variable (and therefore locked in the UI). */
+export const ENV_SMTP_OVERRIDES = {
+  host: ENV.host !== undefined,
+  port: ENV.port !== undefined,
+  secure: ENV.secure !== undefined,
+  user: ENV.user !== undefined,
+  pass: ENV.pass !== undefined,
+  from: ENV.from !== undefined,
+}
+
+const DEFAULTS = { host: 'localhost', port: 1025, secure: false, from: 'noreply@roomer.local' }
+
+export interface StoredEmailConfig {
+  host?: string
+  port?: number
+  secure?: boolean
+  user?: string
+  from?: string
+  /** Encrypted (enc:v1:…) at rest. */
+  password?: string
+}
+
+export interface EffectiveSmtp {
+  host: string
+  port: number
+  secure: boolean
+  user?: string
+  pass?: string
+  from: string
+}
+
+/** Read the admin-configured email settings from the DB (password decrypted). */
+export async function getStoredEmailConfig(): Promise<StoredEmailConfig> {
+  const org = await prisma.organisation.findFirst({ select: { emailConfig: true } })
+  return ((org?.emailConfig ?? {}) as StoredEmailConfig)
+}
+
+/**
+ * Resolve the SMTP settings actually used to send mail.
+ * Precedence per field: environment variable (if set at startup) → DB/UI value → default.
+ */
+export async function getEffectiveSmtp(): Promise<EffectiveSmtp> {
+  const db = await getStoredEmailConfig()
+  const dbPass = typeof db.password === 'string' && db.password ? decryptStringMaybe(db.password) : undefined
+
+  return {
+    host: ENV.host ?? db.host ?? DEFAULTS.host,
+    port: ENV.port !== undefined ? Number(ENV.port) : (db.port ?? DEFAULTS.port),
+    secure: ENV.secure !== undefined ? ENV.secure === 'true' : (db.secure ?? DEFAULTS.secure),
+    user: ENV.user ?? db.user ?? undefined,
+    pass: ENV.pass ?? dbPass ?? undefined,
+    from: ENV.from ?? db.from ?? DEFAULTS.from,
+  }
+}
+
+/** Effective values safe to show in the UI for env-overridden fields (no password). */
+export async function getEffectiveSmtpForDisplay(): Promise<Omit<EffectiveSmtp, 'pass'>> {
+  const { pass: _pass, ...rest } = await getEffectiveSmtp()
+  return rest
+}

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -12,8 +12,20 @@ import { hashScimToken, generateScimToken } from '../lib/scim-helpers.js'
 import { findAuthConfig, listAuthConfigs, upsertAuthConfig } from '../lib/prisma.js'
 import { idpGroupMatchesAny } from '../lib/group-mapping.js'
 import { saveBrandingImage, resolveStoragePath } from '../lib/storage.js'
-import { DEFAULT_TEMPLATE_STRINGS, interpolateTemplate, stripHtmlToText, formatDate, sendEmail } from '../lib/mailer.js'
+import { DEFAULT_TEMPLATE_STRINGS, interpolateTemplate, stripHtmlToText, formatDate, sendEmail, resetMailer } from '../lib/mailer.js'
+import { encrypt } from '../lib/encryption.js'
+import { ENV_SMTP_OVERRIDES, getStoredEmailConfig, getEffectiveSmtpForDisplay, type StoredEmailConfig } from '../lib/smtp-config.js'
 import { z } from 'zod'
+
+const emailConfigSchema = z.object({
+  host: z.string().max(255).optional(),
+  port: z.coerce.number().int().min(1).max(65535).optional(),
+  secure: z.boolean().optional(),
+  user: z.string().max(255).optional(),
+  from: z.string().max(320).optional(),
+  // Omit/blank = keep existing stored password; a value sets a new one.
+  password: z.string().max(1024).optional(),
+})
 
 const ALLOWED_PROVIDERS = ['OIDC', 'SAML', 'LDAP'] as const
 type ProviderKey = (typeof ALLOWED_PROVIDERS)[number]
@@ -189,12 +201,76 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
     },
   )
 
+  // GET /settings/email — SMTP settings for the admin UI.
+  // Returns the stored (editable) values, which fields are env-locked, and the
+  // effective (env-wins) values for display.
+  fastify.get(
+    '/email',
+    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    async (_request, reply) => {
+      const stored = await getStoredEmailConfig()
+      const effective = await getEffectiveSmtpForDisplay()
+      return reply.status(200).send({
+        data: {
+          host: stored.host ?? '',
+          port: stored.port ?? null,
+          secure: stored.secure ?? false,
+          user: stored.user ?? '',
+          from: stored.from ?? '',
+          hasPassword: !!stored.password,
+          envOverrides: ENV_SMTP_OVERRIDES,
+          effective, // { host, port, secure, user, from } — what is actually used
+        },
+      })
+    },
+  )
+
+  // PUT /settings/email — update the stored SMTP settings (env vars still override).
+  fastify.put(
+    '/email',
+    { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
+    async (request, reply) => {
+      const result = emailConfigSchema.safeParse(request.body)
+      if (!result.success) {
+        return reply.status(400).send({ error: { message: 'Validation failed', code: 'VALIDATION_ERROR', details: result.error.flatten() } })
+      }
+      const org = await prisma.organisation.findFirst()
+      if (!org) return reply.status(404).send({ error: { message: 'Organisation not found', code: 'NOT_FOUND' } })
+
+      const existing = (org.emailConfig ?? {}) as StoredEmailConfig
+      const { password, ...rest } = result.data
+      const next: StoredEmailConfig = {
+        ...existing,
+        host: rest.host ?? undefined,
+        port: rest.port ?? undefined,
+        secure: rest.secure ?? undefined,
+        user: rest.user ?? undefined,
+        from: rest.from ?? undefined,
+        // Keep the existing encrypted password unless a new non-empty one is provided.
+        password: password ? encrypt(password) : existing.password,
+      }
+
+      await prisma.organisation.update({ where: { id: org.id }, data: { emailConfig: next as Prisma.InputJsonValue } })
+      resetMailer() // re-resolve transporter on next send
+
+      const effective = await getEffectiveSmtpForDisplay()
+      return reply.status(200).send({
+        data: {
+          host: next.host ?? '', port: next.port ?? null, secure: next.secure ?? false,
+          user: next.user ?? '', from: next.from ?? '', hasPassword: !!next.password,
+          envOverrides: ENV_SMTP_OVERRIDES, effective,
+        },
+      })
+    },
+  )
+
   // POST /settings/test-email — send a test email to verify SMTP config
   fastify.post(
     '/test-email',
     { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] },
     async (request, reply) => {
       const recipient = request.user.email
+      const smtp = await getEffectiveSmtpForDisplay()
 
       try {
         await sendEmail({
@@ -219,14 +295,14 @@ export async function settingsRoutes(fastify: FastifyInstance): Promise<void> {
     <p><span class="badge">✓ Success</span></p>
     <p>Your SMTP configuration is working correctly. Roomer can send email notifications.</p>
     <p style="color:#71717a; font-size:13px;">
-      Host: ${env.SMTP_HOST}:${env.SMTP_PORT}<br/>
-      From: ${env.EMAIL_FROM}
+      Host: ${smtp.host}:${smtp.port}<br/>
+      From: ${smtp.from}
     </p>
     <div class="footer">Roomer — Desk &amp; Asset Management</div>
   </div>
 </body>
 </html>`,
-          text: `Roomer test email\n\nYour SMTP configuration is working correctly.\n\nHost: ${env.SMTP_HOST}:${env.SMTP_PORT}\nFrom: ${env.EMAIL_FROM}`,
+          text: `Roomer test email\n\nYour SMTP configuration is working correctly.\n\nHost: ${smtp.host}:${smtp.port}\nFrom: ${smtp.from}`,
         })
 
         return reply.status(200).send({

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -510,9 +510,23 @@ export const brandingApi = {
   getFaviconUrl: () => `${BASE}/settings/branding/favicon/image`,
 }
 
+export type EmailSettings = {
+  host: string
+  port: number | null
+  secure: boolean
+  user: string
+  from: string
+  hasPassword: boolean
+  envOverrides: { host: boolean; port: boolean; secure: boolean; user: boolean; pass: boolean; from: boolean }
+  effective: { host: string; port: number; secure: boolean; user?: string; from: string }
+}
+
 export const settingsApi = {
   testEmail: (to?: string) =>
     api.post<{ data: { ok: true; message: string } }>('/settings/test-email', to ? { to } : {}),
+  getEmail: () => api.get<{ data: EmailSettings }>('/settings/email'),
+  updateEmail: (body: Partial<{ host: string; port: number; secure: boolean; user: string; from: string; password: string }>) =>
+    api.put<{ data: EmailSettings }>('/settings/email', body),
   getAuthConfig: () =>
     api.get<{ data: Record<string, { enabled: boolean; config: Record<string, unknown> }> }>('/settings/auth-config'),
   updateAuthConfig: (

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -204,31 +204,101 @@ function OrgSettingsCard() {
 }
 
 function EmailSettingsCard() {
+  const qc = useQueryClient()
+  const { data } = useQuery({
+    queryKey: ['settings', 'email'],
+    queryFn: () => settingsApi.getEmail(),
+    select: (r) => r.data,
+  })
+
+  const [host, setHost] = useState('')
+  const [port, setPort] = useState('')
+  const [secure, setSecure] = useState(false)
+  const [user, setUser] = useState('')
+  const [from, setFrom] = useState('')
+  const [password, setPassword] = useState('')
+
+  useEffect(() => {
+    if (data) {
+      setHost(data.host)
+      setPort(data.port != null ? String(data.port) : '')
+      setSecure(data.secure)
+      setUser(data.user)
+      setFrom(data.from)
+      setPassword('')
+    }
+  }, [data])
+
+  const ov = data?.envOverrides
+  const eff = data?.effective
+
+  const save = useMutation({
+    mutationFn: () => settingsApi.updateEmail({
+      host: host || undefined,
+      port: port ? Number(port) : undefined,
+      secure,
+      user: user || undefined,
+      from: from || undefined,
+      ...(password ? { password } : {}),
+    }),
+    onSuccess: () => { toast.success('Email settings saved'); setPassword(''); qc.invalidateQueries({ queryKey: ['settings', 'email'] }) },
+    onError: (err: Error) => toast.error(err.message || 'Failed to save'),
+  })
+
   const testEmail = useMutation({
     mutationFn: () => settingsApi.testEmail(),
     onSuccess: (res) => toast.success(res.data.message),
     onError: (err: Error) => toast.error(err.message),
   })
 
+  const anyEnvOverride = ov && Object.values(ov).some(Boolean)
+
   return (
     <CollapsibleCard title="Email" description="SMTP configuration for outbound notifications">
       <div className="space-y-4">
-        <div className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-          SMTP settings are configured via environment variables (<code className="font-mono text-xs">SMTP_HOST</code>,{' '}
-          <code className="font-mono text-xs">SMTP_PORT</code>,{' '}
-          <code className="font-mono text-xs">SMTP_USER</code>,{' '}
-          <code className="font-mono text-xs">SMTP_PASS</code>,{' '}
-          <code className="font-mono text-xs">EMAIL_FROM</code>). Update your <code className="font-mono text-xs">.env</code>{' '}
-          file and restart the API to change email configuration.
+        {anyEnvOverride && (
+          <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+            Some fields are set by environment variables and take precedence over these settings (shown locked). Unset the matching <code className="font-mono">SMTP_*</code> / <code className="font-mono">EMAIL_FROM</code> env var and restart the API to edit them here.
+          </div>
+        )}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <Label className="text-xs">SMTP host</Label>
+            <Input value={ov?.host ? (eff?.host ?? '') : host} onChange={(e) => setHost(e.target.value)} disabled={ov?.host} className="mt-1 h-8 text-sm" placeholder="smtp.example.com" />
+            {ov?.host && <p className="text-[11px] text-muted-foreground mt-1">Set by environment</p>}
+          </div>
+          <div>
+            <Label className="text-xs">Port</Label>
+            <Input type="number" value={ov?.port ? String(eff?.port ?? '') : port} onChange={(e) => setPort(e.target.value)} disabled={ov?.port} className="mt-1 h-8 text-sm" placeholder="587" />
+            {ov?.port && <p className="text-[11px] text-muted-foreground mt-1">Set by environment</p>}
+          </div>
+          <div>
+            <Label className="text-xs">Username</Label>
+            <Input value={ov?.user ? (eff?.user ?? '') : user} onChange={(e) => setUser(e.target.value)} disabled={ov?.user} className="mt-1 h-8 text-sm" placeholder="(optional)" />
+            {ov?.user && <p className="text-[11px] text-muted-foreground mt-1">Set by environment</p>}
+          </div>
+          <div>
+            <Label className="text-xs">Password</Label>
+            <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} disabled={ov?.pass} className="mt-1 h-8 text-sm" placeholder={ov?.pass ? 'Set by environment' : (data?.hasPassword ? '•••••••• (unchanged)' : '(optional)')} />
+            {ov?.pass && <p className="text-[11px] text-muted-foreground mt-1">Set by environment</p>}
+          </div>
+          <div>
+            <Label className="text-xs">From address</Label>
+            <Input value={ov?.from ? (eff?.from ?? '') : from} onChange={(e) => setFrom(e.target.value)} disabled={ov?.from} className="mt-1 h-8 text-sm" placeholder="noreply@example.com" />
+            {ov?.from && <p className="text-[11px] text-muted-foreground mt-1">Set by environment</p>}
+          </div>
+          <div className="flex items-end">
+            <label className="flex items-center gap-2 text-sm h-8">
+              <input type="checkbox" className="h-4 w-4" checked={ov?.secure ? (eff?.secure ?? false) : secure} onChange={(e) => setSecure(e.target.checked)} disabled={ov?.secure} />
+              <span>Use TLS (secure)</span>
+            </label>
+          </div>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={testEmail.isPending}
-            onClick={() => testEmail.mutate()}
-          >
+          <Button type="button" size="sm" disabled={save.isPending} onClick={() => save.mutate()}>
+            {save.isPending ? 'Saving…' : 'Save email settings'}
+          </Button>
+          <Button type="button" variant="outline" size="sm" disabled={testEmail.isPending} onClick={() => testEmail.mutate()}>
             <Send className="mr-2 h-3.5 w-3.5" />
             {testEmail.isPending ? 'Sending…' : 'Send test email'}
           </Button>


### PR DESCRIPTION
Restores editable email/SMTP settings in the admin UI (**Settings → Email**), while keeping environment variables authoritative when set — as requested.

## Behaviour
Per field, the effective SMTP config resolves: **environment variable (if set at startup) → DB/UI value → default**. Env-pinned fields render **locked** in the UI ("Set by environment"). Captured once at startup, so env overrides apply on boot.

Verified in dev (where `.env` sets the SMTP vars): GET returns `envOverrides` all true + the effective values; saving `from` in the UI persists to the DB but `effective.from` stays the env value — i.e. env wins at runtime.

## Changes
- **Schema:** `Organisation.emailConfig` (host/port/secure/user/from + **encrypted** password).
- **`lib/smtp-config.ts`:** startup env snapshot + `getEffectiveSmtp()` resolver + `ENV_SMTP_OVERRIDES`.
- **`mailer.ts`:** uses the effective config; `resetMailer()` re-resolves after a save (no restart needed; env-pinned fields stay pinned).
- **API:** `GET/PUT /settings/email` — stored values, env-lock flags, effective values; password encrypted at rest and never returned. `test-email` now reports the effective host/from.
- **Web:** Settings → Email is an editable form with locked env-overridden fields.
- **Docs:** README note on the UI + env-override precedence.

## Notes
- Reuses the existing AES-GCM `encrypt()` for the SMTP password (same pattern as auth-provider secrets / webhook secrets).
- In a deployment that sets `SMTP_*` in the environment (e.g. the default Docker compose, which pins these to mailpit), those fields show locked — expected, since env wins.
- Migration `20260607000000_org_email_config` (applied to dev DB; `prisma migrate deploy`).

## Test plan
- [x] `pnpm --filter api build`, web `tsc`, api+web lint — clean (0 errors)
- [x] GET/PUT `/settings/email` verified; env override confirmed (saved value stored, env value used)
- [ ] Manual: with no SMTP env set, edit host/port/from in the UI → test email uses the new values
- [x] Manual: set an `SMTP_HOST` env → that field locks in the UI and is used at runtime