### PR TITLE
feat: manager-derived org hierarchy + side-by-side org chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Roomer is a self-hosted platform for managing desk and asset reservations across
 | **Floor subscriptions** | Users subscribe to a floor and are notified when matching space frees up |
 | **Analytics** | Utilisation and booking analytics for admins and building managers |
 | **Building leases** | Track building lease terms and costs (admin) |
-| **Departments** | Department hierarchy with user membership, mappable from OIDC/SAML/LDAP/SCIM |
+| **Departments & org chart** | Flat departments mapped from OIDC/SAML/LDAP/SCIM, plus an org hierarchy auto-inferred from each user's manager attribute — shown as a side-by-side people/department org chart |
 | **Bulk CSV import** | Import buildings, floors, zones, and assets in a single pass |
 | **Asset registry** | Track non-bookable inventory (laptops, monitors, etc.) alongside bookable space |
 | **Role-based access** | Super admin, building admin, floor manager, and user roles |

--- a/apps/api/prisma/migrations/20260607010000_manager_hierarchy/migration.sql
+++ b/apps/api/prisma/migrations/20260607010000_manager_hierarchy/migration.sql
@@ -1,0 +1,14 @@
+-- Manager-derived org hierarchy: per-user manager link, drop department hierarchy.
+
+-- User manager link (self-relation) + raw IdP ref for deferred resolution.
+ALTER TABLE "User" ADD COLUMN "managerId" TEXT;
+ALTER TABLE "User" ADD COLUMN "managerExternalRef" TEXT;
+ALTER TABLE "User"
+  ADD CONSTRAINT "User_managerId_fkey"
+  FOREIGN KEY ("managerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX "User_managerId_idx" ON "User"("managerId");
+
+-- Departments are now flat — hierarchy is inferred from manager links.
+ALTER TABLE "Department" DROP CONSTRAINT IF EXISTS "Department_parentId_fkey";
+DROP INDEX IF EXISTS "Department_parentId_idx";
+ALTER TABLE "Department" DROP COLUMN IF EXISTS "parentId";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -412,21 +412,19 @@ model AssetAssignment {
   @@index([userId])
 }
 
+/// Departments are a flat, IdP-mapped grouping. Any hierarchy between them is
+/// *inferred* from user manager links (User.managerId), not stored here.
 model Department {
   id             String       @id @default(cuid())
   organisationId String
   name           String
-  parentId       String?
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
   organisation   Organisation @relation(fields: [organisationId], references: [id], onDelete: Cascade)
-  parent         Department?  @relation("DepartmentParent", fields: [parentId], references: [id], onDelete: SetNull)
-  children       Department[] @relation("DepartmentParent")
   members        User[]
 
   @@unique([organisationId, name])
   @@index([organisationId])
-  @@index([parentId])
 }
 
 model User {
@@ -442,6 +440,12 @@ model User {
   /// MANUAL (an admin set it), sync leaves it untouched.
   globalRoleSource        RoleSource    @default(MANUAL)
   departmentId            String?
+  /// The user's manager, derived from the IdP (LDAP `manager` DN, or an OIDC/SAML
+  /// manager claim). Drives the inferred org/department hierarchy.
+  managerId               String?
+  /// Raw manager identifier from the IdP (a DN, email, or UPN) before it is
+  /// resolved to a Roomer user — kept so forward references reconcile on later sync/login.
+  managerExternalRef      String?
   notificationPreferences Json          @default("{}")
   /// When false, the user is hidden from the colleague finder / "who's in"
   /// directory (their bookings and assigned desks are not surfaced to others).
@@ -456,6 +460,8 @@ model User {
   updatedAt               DateTime      @updatedAt
 
   department           Department?  @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+  manager              User?        @relation("UserManager", fields: [managerId], references: [id], onDelete: SetNull)
+  reports              User[]       @relation("UserManager")
   resourceRoles        UserResourceRole[]
   bookings             Booking[]
   queueEntries         QueueEntry[]
@@ -472,6 +478,7 @@ model User {
   @@index([email])
   @@index([provider, externalId])
   @@index([departmentId])
+  @@index([managerId])
 }
 
 model UserGroup {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -29,6 +29,7 @@ import { subscriptionRoutes } from './routes/subscriptions.js'
 import { recurringBookingRoutes } from './routes/recurring.js'
 import { webhookRoutes } from './routes/webhooks.js'
 import { directoryRoutes } from './routes/directory.js'
+import { orgRoutes } from './routes/org.js'
 import { getBoss } from './lib/queue.js'
 import { prisma } from './lib/prisma.js'
 import { register, httpRequestDuration, setupMetrics } from './lib/metrics.js'
@@ -236,6 +237,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(recurringBookingRoutes, { prefix: '/api/v1/recurring-bookings' })
   await fastify.register(scimRoutes, { prefix: '/scim/v2' })
   await fastify.register(departmentRoutes, { prefix: '/api/v1/departments' })
+  await fastify.register(orgRoutes, { prefix: '/api/v1/org' })
   await fastify.register(webhookRoutes, { prefix: '/api/v1/webhooks' })
   await fastify.register(directoryRoutes, { prefix: '/api/v1/directory' })
 

--- a/apps/api/src/lib/ldap.ts
+++ b/apps/api/src/lib/ldap.ts
@@ -26,12 +26,15 @@ export interface LdapConfig {
   deactivateMissing?: boolean
   /** LDAP attribute containing the user's department name (e.g. 'department') */
   departmentAttribute?: string
+  /** LDAP attribute containing the user's manager DN (e.g. 'manager') */
+  managerAttribute?: string
 }
 
 export interface LdapSyncResult {
   created: number
   updated: number
   deactivated: number
+  managersResolved?: number
   skipped: number
   errors: Array<{ dn: string; message: string }>
 }
@@ -101,6 +104,7 @@ export async function syncLdapUsers(cfg: LdapConfig): Promise<LdapSyncResult> {
   const nameAttr = cfg.displayNameAttribute ?? 'displayName'
   const groupAttr = cfg.groupAttribute ?? 'memberOf'
   const deptAttr = cfg.departmentAttribute
+  const managerAttr = cfg.managerAttribute
   const syncBase = cfg.syncBase?.trim() || cfg.searchBase
   const syncFilter = cfg.syncFilter?.trim() || '(objectClass=person)'
   const syncScope = cfg.syncScope ?? 'sub'
@@ -118,6 +122,7 @@ export async function syncLdapUsers(cfg: LdapConfig): Promise<LdapSyncResult> {
 
     const attrs = ['dn', emailAttr, nameAttr, groupAttr]
     if (deptAttr) attrs.push(deptAttr)
+    if (managerAttr) attrs.push(managerAttr)
 
     const entries = await searchAsync(client, syncBase, {
       filter: syncFilter,
@@ -137,6 +142,7 @@ export async function syncLdapUsers(cfg: LdapConfig): Promise<LdapSyncResult> {
       const displayName = getAttr(nameAttr)?.values[0]?.trim() || email
       const groups = (getAttr(groupAttr)?.values ?? []).map((g) => g.trim().toLowerCase())
       const departmentName = deptAttr ? getAttr(deptAttr)?.values[0]?.trim() : undefined
+      const managerRef = managerAttr ? (getAttr(managerAttr)?.values[0]?.trim() || null) : undefined
       const dn = entry.dn.toString()
 
       seenEmails.add(email)
@@ -146,12 +152,18 @@ export async function syncLdapUsers(cfg: LdapConfig): Promise<LdapSyncResult> {
         if (existing) {
           await prisma.user.update({
             where: { email },
-            data: { displayName, accountStatus: 'ACTIVE', provider: 'LDAP' },
+            data: {
+              displayName, accountStatus: 'ACTIVE', provider: 'LDAP', externalId: dn,
+              ...(managerAttr ? { managerExternalRef: managerRef } : {}),
+            },
           })
           result.updated++
         } else {
           await prisma.user.create({
-            data: { email, displayName, provider: 'LDAP', externalId: dn },
+            data: {
+              email, displayName, provider: 'LDAP', externalId: dn,
+              ...(managerAttr ? { managerExternalRef: managerRef } : {}),
+            },
           })
           result.created++
         }
@@ -184,6 +196,13 @@ export async function syncLdapUsers(cfg: LdapConfig): Promise<LdapSyncResult> {
     }
   } finally {
     unbind(client)
+  }
+
+  // Resolve manager DNs → managerId now that all users are present.
+  if (managerAttr) {
+    const { reconcileAllManagers } = await import('./manager.js')
+    const { resolved } = await reconcileAllManagers()
+    result.managersResolved = resolved
   }
 
   if (result.created > 0 || result.updated > 0) {

--- a/apps/api/src/lib/manager.ts
+++ b/apps/api/src/lib/manager.ts
@@ -1,0 +1,91 @@
+import { prisma } from './prisma.js'
+
+/** Normalise a manager reference (DN / email / UPN) for comparison. */
+function normRef(s: string): string {
+  return s.trim().toLowerCase().replace(/\s*,\s*/g, ',')
+}
+
+function userKeys(u: { externalId: string | null; email: string }): string[] {
+  const keys: string[] = []
+  if (u.externalId) keys.push(normRef(u.externalId))
+  if (u.email) keys.push(normRef(u.email))
+  return keys
+}
+
+/** Store the raw manager identifier from the IdP (DN/email/UPN). */
+export async function recordManagerRef(userId: string, ref: string | null | undefined): Promise<void> {
+  const value = ref && ref.trim() ? ref.trim() : null
+  await prisma.user.update({ where: { id: userId }, data: { managerExternalRef: value } })
+}
+
+/**
+ * Resolve every user's managerExternalRef → managerId in one pass.
+ * Used after a bulk LDAP sync. Handles DN whitespace normalisation in memory
+ * (which a SQL query can't), and self-references are ignored.
+ * Returns counts for logging.
+ */
+export async function reconcileAllManagers(): Promise<{ resolved: number; unresolved: number }> {
+  const users = await prisma.user.findMany({
+    select: { id: true, email: true, externalId: true, managerExternalRef: true, managerId: true },
+  })
+  const byKey = new Map<string, string>()
+  for (const u of users) for (const k of userKeys(u)) byKey.set(k, u.id)
+
+  let resolved = 0
+  let unresolved = 0
+  const updates: Array<{ id: string; managerId: string | null }> = []
+  for (const u of users) {
+    if (!u.managerExternalRef) {
+      if (u.managerId !== null) updates.push({ id: u.id, managerId: null })
+      continue
+    }
+    const found = byKey.get(normRef(u.managerExternalRef))
+    const target = found && found !== u.id ? found : null
+    if (target) resolved++
+    else unresolved++
+    if (u.managerId !== target) updates.push({ id: u.id, managerId: target })
+  }
+
+  // Chunk the updates to keep transactions reasonable.
+  for (let i = 0; i < updates.length; i += 100) {
+    const chunk = updates.slice(i, i + 100)
+    await prisma.$transaction(chunk.map((up) => prisma.user.update({ where: { id: up.id }, data: { managerId: up.managerId } })))
+  }
+  return { resolved, unresolved }
+}
+
+/**
+ * Incrementally resolve one user (used on SSO login):
+ *   1. Link this user to their manager (by externalId / email, case-insensitive).
+ *   2. Link any existing reports that referenced this user (forward references).
+ */
+export async function resolveManagerForUser(userId: string): Promise<void> {
+  const u = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, externalId: true, managerExternalRef: true },
+  })
+  if (!u) return
+
+  if (u.managerExternalRef) {
+    const mgr = await prisma.user.findFirst({
+      where: {
+        id: { not: u.id },
+        OR: [
+          { externalId: { equals: u.managerExternalRef, mode: 'insensitive' } },
+          { email: { equals: u.managerExternalRef, mode: 'insensitive' } },
+        ],
+      },
+      select: { id: true },
+    })
+    await prisma.user.update({ where: { id: u.id }, data: { managerId: mgr?.id ?? null } })
+  }
+
+  // Forward references: reports whose stored ref points at this user's DN/email.
+  const refs = [u.externalId, u.email].filter((x): x is string => !!x)
+  if (refs.length) {
+    await prisma.user.updateMany({
+      where: { id: { not: u.id }, managerId: null, managerExternalRef: { in: refs } },
+      data: { managerId: u.id },
+    })
+  }
+}

--- a/apps/api/src/lib/oidc.ts
+++ b/apps/api/src/lib/oidc.ts
@@ -13,6 +13,8 @@ export interface OidcConfig {
   groupsClaimName?: string
   /** Userinfo claim name to map to the user's Roomer department. Blank = disabled. */
   departmentClaimName?: string
+  /** Userinfo claim name holding the user's manager (email/UPN). Blank = disabled. */
+  managerClaimName?: string
   groupMappings?: GroupMapping[]
 }
 

--- a/apps/api/src/lib/saml.ts
+++ b/apps/api/src/lib/saml.ts
@@ -20,6 +20,8 @@ export interface SamlConfig {
   allowClockSkewMs?: number
   /** SAML attribute containing department name (default: department) */
   departmentAttribute?: string
+  /** SAML attribute containing the user's manager (email/UPN). Blank = disabled. */
+  managerAttribute?: string
 }
 
 export async function getSamlConfig(): Promise<SamlConfig | null> {
@@ -86,6 +88,17 @@ export function extractDepartmentFromProfile(profile: SamlProfile, attribute?: s
   const val = profile[attr]
   if (typeof val === 'string' && val.trim()) return val.trim()
   const msVal = profile['http://schemas.microsoft.com/identity/claims/department']
+  if (typeof msVal === 'string' && msVal.trim()) return msVal.trim()
+  return null
+}
+
+export function extractManagerFromProfile(profile: SamlProfile, attribute?: string): string | null {
+  if (attribute) {
+    const val = profile[attribute]
+    if (typeof val === 'string' && val.trim()) return val.trim()
+  }
+  // Common AD FS / Entra manager claim URI.
+  const msVal = profile['http://schemas.microsoft.com/ws/2008/06/identity/claims/manager']
   if (typeof msVal === 'string' && msVal.trim()) return msVal.trim()
   return null
 }

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -698,10 +698,12 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       if (!root) return reply.status(404).send({ error: { message: 'User not found', code: 'NOT_FOUND' } })
 
       type Totals = { peopleCount: bigint; bookingCount: bigint; deskDays: string | null }
+      // UNION (not UNION ALL) so a manager cycle (A→B→A from bad IdP data) can't
+      // recurse infinitely — duplicate ids are dropped, terminating traversal.
       const [overall] = await prisma.$queryRaw<Totals[]>`
         WITH RECURSIVE subtree AS (
           SELECT id FROM "User" WHERE id = ${userId}
-          UNION ALL
+          UNION
           SELECT u.id FROM "User" u JOIN subtree s ON u."managerId" = s.id
         )
         SELECT
@@ -714,10 +716,11 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       `
 
       type BranchRow = Totals & { rootId: string; rootName: string }
+      // UNION (see subtree CTE above) to guarantee termination on cyclic manager data.
       const branches = await prisma.$queryRaw<BranchRow[]>`
         WITH RECURSIVE branch AS (
           SELECT id, id AS root FROM "User" WHERE "managerId" = ${userId}
-          UNION ALL
+          UNION
           SELECT u.id, br.root FROM "User" u JOIN branch br ON u."managerId" = br.id
         )
         SELECT

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -675,4 +675,80 @@ export async function analyticsRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.status(200).send({ data })
     },
   )
+
+  // GET /analytics/manager-rollup?userId= — aggregate bookings/desk-days for a
+  // manager's entire reporting subtree, plus a per-direct-report breakdown.
+  fastify.get(
+    '/manager-rollup',
+    { preHandler: [requireAuth] },
+    async (request, reply) => {
+      if (request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+        return reply.status(403).send({ error: { message: 'Forbidden', code: 'FORBIDDEN' } })
+      }
+      const result = analyticsQuerySchema.extend({ userId: z.string().min(1) }).safeParse(request.query)
+      if (!result.success) {
+        return reply.status(400).send({ error: { message: 'userId and valid dates are required', code: 'VALIDATION_ERROR' } })
+      }
+      const { startDate: sd, endDate: ed } = defaultDateRange()
+      const startDate = parseDateParam(result.data.startDate, 'T00:00:00.000Z', sd)
+      const endDate = parseDateParam(result.data.endDate, 'T23:59:59.999Z', ed)
+      const userId = result.data.userId
+
+      const root = await prisma.user.findUnique({ where: { id: userId }, select: { id: true, displayName: true, email: true } })
+      if (!root) return reply.status(404).send({ error: { message: 'User not found', code: 'NOT_FOUND' } })
+
+      type Totals = { peopleCount: bigint; bookingCount: bigint; deskDays: string | null }
+      const [overall] = await prisma.$queryRaw<Totals[]>`
+        WITH RECURSIVE subtree AS (
+          SELECT id FROM "User" WHERE id = ${userId}
+          UNION ALL
+          SELECT u.id FROM "User" u JOIN subtree s ON u."managerId" = s.id
+        )
+        SELECT
+          COUNT(DISTINCT s.id)::bigint AS "peopleCount",
+          COUNT(DISTINCT b.id)::bigint AS "bookingCount",
+          ROUND(CAST(COALESCE(SUM(EXTRACT(EPOCH FROM (b."endsAt" - b."startsAt")) / 3600 / 8), 0) AS NUMERIC), 2)::text AS "deskDays"
+        FROM subtree s
+        LEFT JOIN "Booking" b ON b."userId" = s.id
+          AND b."startsAt" >= ${startDate} AND b."startsAt" <= ${endDate} AND b.status = 'CONFIRMED'
+      `
+
+      type BranchRow = Totals & { rootId: string; rootName: string }
+      const branches = await prisma.$queryRaw<BranchRow[]>`
+        WITH RECURSIVE branch AS (
+          SELECT id, id AS root FROM "User" WHERE "managerId" = ${userId}
+          UNION ALL
+          SELECT u.id, br.root FROM "User" u JOIN branch br ON u."managerId" = br.id
+        )
+        SELECT
+          br.root AS "rootId",
+          ru."displayName" AS "rootName",
+          COUNT(DISTINCT br.id)::bigint AS "peopleCount",
+          COUNT(DISTINCT b.id)::bigint AS "bookingCount",
+          ROUND(CAST(COALESCE(SUM(EXTRACT(EPOCH FROM (b."endsAt" - b."startsAt")) / 3600 / 8), 0) AS NUMERIC), 2)::text AS "deskDays"
+        FROM branch br
+        JOIN "User" ru ON ru.id = br.root
+        LEFT JOIN "Booking" b ON b."userId" = br.id
+          AND b."startsAt" >= ${startDate} AND b."startsAt" <= ${endDate} AND b.status = 'CONFIRMED'
+        GROUP BY br.root, ru."displayName"
+        ORDER BY "deskDays"::numeric DESC NULLS LAST
+      `
+
+      return reply.status(200).send({
+        data: {
+          manager: { id: root.id, displayName: root.displayName, email: root.email },
+          peopleCount: Number(overall?.peopleCount ?? 0),
+          bookingCount: Number(overall?.bookingCount ?? 0),
+          deskDays: Number(overall?.deskDays ?? 0),
+          directReports: branches.map((b) => ({
+            rootId: b.rootId,
+            rootName: b.rootName,
+            peopleCount: Number(b.peopleCount),
+            bookingCount: Number(b.bookingCount),
+            deskDays: Number(b.deskDays ?? 0),
+          })),
+        },
+      })
+    },
+  )
 }

--- a/apps/api/src/routes/auth-enterprise.ts
+++ b/apps/api/src/routes/auth-enterprise.ts
@@ -3,8 +3,9 @@ import { prisma } from '../lib/prisma.js'
 import { env } from '../env.js'
 import { getOidcClientConfig, getOidcConfig, generateState, generateNonce } from '../lib/oidc.js'
 import { buildAuthorizationUrl, authorizationCodeGrant, fetchUserInfo, skipSubjectCheck } from 'openid-client'
-import { getSamlConfig, buildSaml, extractEmailFromProfile, extractDisplayNameFromProfile, extractGroupsFromProfile, extractDepartmentFromProfile, type SamlProfile } from '../lib/saml.js'
+import { getSamlConfig, buildSaml, extractEmailFromProfile, extractDisplayNameFromProfile, extractGroupsFromProfile, extractDepartmentFromProfile, extractManagerFromProfile, type SamlProfile } from '../lib/saml.js'
 import { applyGroupMappings, recordLastIdpGroups } from '../lib/group-mapping.js'
+import { recordManagerRef, resolveManagerForUser } from '../lib/manager.js'
 import { signAccessToken, TOKEN_COOKIE, TOKEN_COOKIE_OPTS, TOKEN_MAX_AGE } from '../lib/jwt.js'
 import type { User } from '@prisma/client'
 
@@ -196,6 +197,13 @@ export async function enterpriseAuthRoutes(fastify: FastifyInstance): Promise<vo
         }
       }
 
+      // Manager mapping — opt-in via a configured claim (blank = disabled).
+      if (cfg.managerClaimName) {
+        const rawMgr = (userinfo as Record<string, unknown>)[cfg.managerClaimName]
+        await recordManagerRef(user.id, typeof rawMgr === 'string' ? rawMgr : null)
+      }
+      await resolveManagerForUser(user.id)
+
       // Issue JWT cookie — OIDC session state is no longer needed
       issueSsoToken(reply, user)
     } catch (err) {
@@ -271,6 +279,11 @@ export async function enterpriseAuthRoutes(fastify: FastifyInstance): Promise<vo
           await prisma.user.update({ where: { id: user.id }, data: { departmentId: dept.id } })
         }
       }
+
+      // Manager mapping (opt-in via configured attribute; blank = disabled).
+      const mgrRef = extractManagerFromProfile(samlProfile, cfg.managerAttribute)
+      if (cfg.managerAttribute || mgrRef) await recordManagerRef(user.id, mgrRef)
+      await resolveManagerForUser(user.id)
 
       // Issue JWT cookie
       issueSsoToken(reply, user)

--- a/apps/api/src/routes/departments.ts
+++ b/apps/api/src/routes/departments.ts
@@ -8,13 +8,10 @@ import { z } from 'zod'
 export async function departmentRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Departments'], ...route.schema } })
 
-  // GET /departments — list all departments with member + child counts
+  // GET /departments — list all departments with member counts
   fastify.get('/', { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] }, async (_request, reply) => {
     const departments = await prisma.department.findMany({
-      include: {
-        parent: { select: { id: true, name: true } },
-        _count: { select: { members: true, children: true } },
-      },
+      include: { _count: { select: { members: true } } },
       orderBy: [{ name: 'asc' }],
     })
     return reply.status(200).send({ data: departments })
@@ -32,18 +29,10 @@ export async function departmentRoutes(fastify: FastifyInstance): Promise<void> 
     const org = await prisma.organisation.findFirst({ select: { id: true } })
     if (!org) return reply.status(500).send({ error: { message: 'No organisation found', code: 'NO_ORGANISATION' } })
 
-    if (result.data.parentId) {
-      const parent = await prisma.department.findUnique({ where: { id: result.data.parentId }, select: { id: true } })
-      if (!parent) return reply.status(404).send({ error: { message: 'Parent department not found', code: 'NOT_FOUND' } })
-    }
-
     try {
       const department = await prisma.department.create({
-        data: { organisationId: org.id, name: result.data.name, parentId: result.data.parentId ?? null },
-        include: {
-          parent: { select: { id: true, name: true } },
-          _count: { select: { members: true, children: true } },
-        },
+        data: { organisationId: org.id, name: result.data.name },
+        include: { _count: { select: { members: true } } },
       })
       return reply.status(201).send({ data: department })
     } catch {
@@ -57,21 +46,14 @@ export async function departmentRoutes(fastify: FastifyInstance): Promise<void> 
 
     const department = await prisma.department.findUnique({
       where: { id },
-      include: {
-        parent: { select: { id: true, name: true } },
-        children: {
-          select: { id: true, name: true, _count: { select: { members: true } } },
-          orderBy: { name: 'asc' },
-        },
-        _count: { select: { members: true } },
-      },
+      include: { _count: { select: { members: true } } },
     })
     if (!department) return reply.status(404).send({ error: { message: 'Department not found', code: 'NOT_FOUND' } })
 
     return reply.status(200).send({ data: department })
   })
 
-  // PUT /departments/:id — update name or parent
+  // PUT /departments/:id — rename department
   fastify.put('/:id', { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] }, async (request, reply) => {
     const { id } = request.params as { id: string }
     const result = updateDepartmentSchema.safeParse(request.body)
@@ -81,23 +63,11 @@ export async function departmentRoutes(fastify: FastifyInstance): Promise<void> 
       })
     }
 
-    if (result.data.parentId === id) {
-      return reply.status(400).send({ error: { message: 'Department cannot be its own parent', code: 'INVALID_PARENT' } })
-    }
-
-    if (result.data.parentId) {
-      const parent = await prisma.department.findUnique({ where: { id: result.data.parentId }, select: { id: true } })
-      if (!parent) return reply.status(404).send({ error: { message: 'Parent department not found', code: 'NOT_FOUND' } })
-    }
-
     try {
       const department = await prisma.department.update({
         where: { id },
         data: result.data,
-        include: {
-          parent: { select: { id: true, name: true } },
-          _count: { select: { members: true, children: true } },
-        },
+        include: { _count: { select: { members: true } } },
       })
       return reply.status(200).send({ data: department })
     } catch {

--- a/apps/api/src/routes/org.ts
+++ b/apps/api/src/routes/org.ts
@@ -1,0 +1,68 @@
+import type { FastifyInstance } from 'fastify'
+import { prisma } from '../lib/prisma.js'
+import { GlobalRole } from '@roomer/shared'
+import { requireAuth } from '../middleware/requireAuth.js'
+import { requireGlobalRole } from '../middleware/requireRole.js'
+
+export async function orgRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.addHook('onRoute', (route) => { route.schema = { tags: ['Org'], ...route.schema } })
+
+  // GET /org/hierarchy — the people manager-tree plus the department tree
+  // *inferred* from manager links (dept A reports to dept B when A's people
+  // mostly report to people in B). Powers the side-by-side hierarchy view.
+  fastify.get('/hierarchy', { preHandler: [requireAuth, requireGlobalRole(GlobalRole.SUPER_ADMIN)] }, async (_request, reply) => {
+    const [users, departments] = await Promise.all([
+      prisma.user.findMany({
+        where: { accountStatus: 'ACTIVE' },
+        select: { id: true, displayName: true, email: true, departmentId: true, managerId: true },
+        orderBy: { displayName: 'asc' },
+      }),
+      prisma.department.findMany({ select: { id: true, name: true }, orderBy: { name: 'asc' } }),
+    ])
+
+    const deptOf = new Map<string, string | null>()
+    const memberCount = new Map<string, number>()
+    for (const u of users) {
+      deptOf.set(u.id, u.departmentId)
+      if (u.departmentId) memberCount.set(u.departmentId, (memberCount.get(u.departmentId) ?? 0) + 1)
+    }
+
+    // Tally, per department, the departments its members report INTO (cross-dept only).
+    const parentVotes = new Map<string, Map<string, number>>()
+    for (const u of users) {
+      if (!u.managerId || !u.departmentId) continue
+      const mgrDept = deptOf.get(u.managerId) ?? null
+      if (!mgrDept || mgrDept === u.departmentId) continue
+      let votes = parentVotes.get(u.departmentId)
+      if (!votes) { votes = new Map(); parentVotes.set(u.departmentId, votes) }
+      votes.set(mgrDept, (votes.get(mgrDept) ?? 0) + 1)
+    }
+
+    const inferredParent = new Map<string, string>()
+    for (const [deptId, votes] of parentVotes) {
+      let best: string | null = null
+      let bestN = 0
+      for (const [parent, n] of votes) if (n > bestN) { best = parent; bestN = n }
+      if (best) inferredParent.set(deptId, best)
+    }
+
+    return reply.status(200).send({
+      data: {
+        people: users.map((u) => ({
+          id: u.id,
+          displayName: u.displayName,
+          email: u.email,
+          departmentId: u.departmentId,
+          managerId: u.managerId,
+        })),
+        departments: departments.map((d) => ({
+          id: d.id,
+          name: d.name,
+          memberCount: memberCount.get(d.id) ?? 0,
+          inferredParentId: inferredParent.get(d.id) ?? null,
+        })),
+        unresolvedManagers: users.filter((u) => u.managerId === null).length,
+      },
+    })
+  })
+}

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -76,6 +76,7 @@ const oidcConfigSchema = z.object({
   label: z.string().optional(),
   groupsClaimName: z.string().optional(),
   departmentClaimName: z.string().optional(),
+  managerClaimName: z.string().optional(),
   groupMappings: z.array(groupMappingSchema).optional(),
 })
 
@@ -89,6 +90,7 @@ const samlConfigSchema = z.object({
   groupAttribute: z.string().optional(),
   groupMappings: z.array(groupMappingSchema).optional(),
   departmentAttribute: z.string().optional(),
+  managerAttribute: z.string().optional(),
   // Refuse to disable signature verification in production — disabling either flag
   // turns SAML into an unauthenticated identity assertion (signature-stripping attack).
   wantAuthnResponseSigned: z.boolean()
@@ -116,6 +118,7 @@ const ldapConfigSchema = z.object({
   tlsRejectUnauthorized: z.boolean().optional(),
   groupAttribute: z.string().optional(),
   groupMappings: z.array(groupMappingSchema).optional(),
+  managerAttribute: z.string().optional(),
   // Directory sync settings — nullish so the UI can explicitly clear them
   syncBase: z.string().nullish(),
   syncFilter: z.string().nullish(),

--- a/apps/web/src/components/org/OrgChartCanvas.tsx
+++ b/apps/web/src/components/org/OrgChartCanvas.tsx
@@ -120,8 +120,9 @@ export function OrgChartCanvas({
           onWheel={handleWheel}
           onDragEnd={(e) => setStagePos({ x: e.target.x(), y: e.target.y() })}
         >
-          <Layer>
-            {/* edges */}
+          {/* Edges live in their own non-listening layer so they never take part
+              in hit-testing — large trees stay responsive while panning/zooming. */}
+          <Layer listening={false}>
             {positioned.map((n) => {
               if (!n.parentId) return null
               const p = posById.get(n.parentId)
@@ -132,10 +133,13 @@ export function OrgChartCanvas({
                   points={[p.x, p.y + NODE_H, p.x, p.y + NODE_H + ROW_H / 2, n.x, p.y + NODE_H + ROW_H / 2, n.x, n.y]}
                   stroke="#cbd5e1"
                   strokeWidth={1.5}
+                  perfectDrawEnabled={false}
+                  listening={false}
                 />
               )
             })}
-            {/* nodes */}
+          </Layer>
+          <Layer>
             {positioned.map((n) => {
               const selected = n.id === highlightId
               return (
@@ -147,15 +151,18 @@ export function OrgChartCanvas({
                     fill="#ffffff"
                     stroke={selected ? accent : '#e2e8f0'}
                     strokeWidth={selected ? 3 : 1}
-                    shadowColor="#0f172a"
-                    shadowOpacity={0.08}
-                    shadowBlur={selected ? 10 : 4}
-                    shadowOffsetY={2}
+                    perfectDrawEnabled={false}
+                    shadowForStrokeEnabled={false}
+                    // Shadows force an off-screen canvas per shape — by far the most
+                    // expensive Konva op. Only the selected node pays that cost.
+                    {...(selected
+                      ? { shadowColor: '#0f172a', shadowOpacity: 0.18, shadowBlur: 10, shadowOffsetY: 2 }
+                      : {})}
                   />
-                  <Rect width={4} height={NODE_H} cornerRadius={[8, 0, 0, 8]} fill={accent} />
-                  <Text x={12} y={8} width={NODE_W - 20} text={n.label} fontSize={13} fontStyle="600" fill="#0f172a" ellipsis wrap="none" />
+                  <Rect width={4} height={NODE_H} cornerRadius={[8, 0, 0, 8]} fill={accent} listening={false} perfectDrawEnabled={false} />
+                  <Text x={12} y={8} width={NODE_W - 20} text={n.label} fontSize={13} fontStyle="600" fill="#0f172a" ellipsis wrap="none" listening={false} perfectDrawEnabled={false} />
                   {n.sublabel && (
-                    <Text x={12} y={26} width={NODE_W - 20} text={n.sublabel} fontSize={11} fill="#64748b" ellipsis wrap="none" />
+                    <Text x={12} y={26} width={NODE_W - 20} text={n.sublabel} fontSize={11} fill="#64748b" ellipsis wrap="none" listening={false} perfectDrawEnabled={false} />
                   )}
                 </Group>
               )

--- a/apps/web/src/components/org/OrgChartCanvas.tsx
+++ b/apps/web/src/components/org/OrgChartCanvas.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Stage, Layer, Group, Rect, Text, Line } from 'react-konva'
+import type Konva from 'konva'
+
+export interface OrgNode {
+  id: string
+  label: string
+  sublabel?: string
+  parentId: string | null
+}
+
+const NODE_W = 168
+const NODE_H = 46
+const COL_W = 190
+const ROW_H = 110
+
+type Positioned = OrgNode & { x: number; y: number }
+
+/** Simple top-down tidy-tree layout. Handles forests (multiple roots) and cycles. */
+function layout(nodes: OrgNode[]): { positioned: Positioned[]; width: number; height: number } {
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const children = new Map<string, string[]>()
+  const roots: string[] = []
+  for (const n of nodes) {
+    if (n.parentId && byId.has(n.parentId) && n.parentId !== n.id) {
+      const arr = children.get(n.parentId) ?? []
+      arr.push(n.id)
+      children.set(n.parentId, arr)
+    } else {
+      roots.push(n.id)
+    }
+  }
+
+  const pos = new Map<string, { x: number; y: number }>()
+  const visited = new Set<string>()
+  let nextLeaf = 0
+  let maxDepth = 0
+
+  const place = (id: string, depth: number) => {
+    if (visited.has(id)) return
+    visited.add(id)
+    maxDepth = Math.max(maxDepth, depth)
+    const kids = (children.get(id) ?? []).filter((k) => !visited.has(k))
+    if (kids.length === 0) {
+      pos.set(id, { x: nextLeaf * COL_W, y: depth * ROW_H })
+      nextLeaf++
+    } else {
+      for (const k of kids) place(k, depth + 1)
+      const xs = kids.map((k) => pos.get(k)!.x)
+      pos.set(id, { x: (Math.min(...xs) + Math.max(...xs)) / 2, y: depth * ROW_H })
+    }
+  }
+  for (const r of roots) place(r, 0)
+  // Any nodes left unvisited (cycles) get appended as extra roots.
+  for (const n of nodes) if (!visited.has(n.id)) place(n.id, 0)
+
+  const positioned = nodes.map((n) => ({ ...n, ...(pos.get(n.id) ?? { x: 0, y: 0 }) }))
+  const width = Math.max(NODE_W, nextLeaf * COL_W)
+  const height = (maxDepth + 1) * ROW_H
+  return { positioned, width, height }
+}
+
+export function OrgChartCanvas({
+  nodes,
+  height = 560,
+  highlightId,
+  onSelect,
+  accent = '#6366f1',
+}: {
+  nodes: OrgNode[]
+  height?: number
+  highlightId?: string | null
+  onSelect?: (id: string) => void
+  accent?: string
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(600)
+  const [scale, setScale] = useState(1)
+  const [stagePos, setStagePos] = useState({ x: 20, y: 20 })
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const ro = new ResizeObserver((entries) => setWidth(entries[0].contentRect.width))
+    ro.observe(containerRef.current)
+    return () => ro.disconnect()
+  }, [])
+
+  const { positioned, width: treeW, height: treeH } = useMemo(() => layout(nodes), [nodes])
+  const posById = useMemo(() => new Map(positioned.map((p) => [p.id, p])), [positioned])
+
+  // Auto-fit when the tree or viewport changes.
+  useEffect(() => {
+    if (treeW <= 0 || treeH <= 0) return
+    const pad = 40
+    const s = Math.min(1.2, (width - pad) / (treeW + NODE_W), (height - pad) / (treeH + NODE_H))
+    const fit = Math.max(0.15, Number.isFinite(s) ? s : 1)
+    setScale(fit)
+    setStagePos({ x: (width - (treeW + NODE_W) * fit) / 2 + (NODE_W / 2) * fit, y: 24 })
+  }, [treeW, treeH, width, height])
+
+  function handleWheel(e: Konva.KonvaEventObject<WheelEvent>) {
+    e.evt.preventDefault()
+    const factor = e.evt.deltaY > 0 ? 0.9 : 1.1
+    setScale((s) => Math.min(2.5, Math.max(0.1, s * factor)))
+  }
+
+  return (
+    <div ref={containerRef} className="w-full rounded-md border bg-muted/20 overflow-hidden" style={{ height }}>
+      {nodes.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">No data to display</div>
+      ) : (
+        <Stage
+          width={width}
+          height={height}
+          draggable
+          x={stagePos.x}
+          y={stagePos.y}
+          scaleX={scale}
+          scaleY={scale}
+          onWheel={handleWheel}
+          onDragEnd={(e) => setStagePos({ x: e.target.x(), y: e.target.y() })}
+        >
+          <Layer>
+            {/* edges */}
+            {positioned.map((n) => {
+              if (!n.parentId) return null
+              const p = posById.get(n.parentId)
+              if (!p || p.id === n.id) return null
+              return (
+                <Line
+                  key={`e-${n.id}`}
+                  points={[p.x, p.y + NODE_H, p.x, p.y + NODE_H + ROW_H / 2, n.x, p.y + NODE_H + ROW_H / 2, n.x, n.y]}
+                  stroke="#cbd5e1"
+                  strokeWidth={1.5}
+                />
+              )
+            })}
+            {/* nodes */}
+            {positioned.map((n) => {
+              const selected = n.id === highlightId
+              return (
+                <Group key={n.id} x={n.x - NODE_W / 2} y={n.y} onClick={() => onSelect?.(n.id)} onTap={() => onSelect?.(n.id)}>
+                  <Rect
+                    width={NODE_W}
+                    height={NODE_H}
+                    cornerRadius={8}
+                    fill="#ffffff"
+                    stroke={selected ? accent : '#e2e8f0'}
+                    strokeWidth={selected ? 3 : 1}
+                    shadowColor="#0f172a"
+                    shadowOpacity={0.08}
+                    shadowBlur={selected ? 10 : 4}
+                    shadowOffsetY={2}
+                  />
+                  <Rect width={4} height={NODE_H} cornerRadius={[8, 0, 0, 8]} fill={accent} />
+                  <Text x={12} y={8} width={NODE_W - 20} text={n.label} fontSize={13} fontStyle="600" fill="#0f172a" ellipsis wrap="none" />
+                  {n.sublabel && (
+                    <Text x={12} y={26} width={NODE_W - 20} text={n.sublabel} fontSize={11} fill="#64748b" ellipsis wrap="none" />
+                  )}
+                </Group>
+              )
+            })}
+          </Layer>
+        </Stage>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useNavConfig.ts
+++ b/apps/web/src/hooks/useNavConfig.ts
@@ -86,6 +86,7 @@ export function useNavConfig() {
           { to: '/admin/buildings', icon: Building2, label: 'Buildings' },
           { to: '/admin/users', icon: Users, label: 'Users' },
           { to: '/admin/departments', icon: Network, label: 'Departments' },
+          { to: '/admin/org-chart', icon: Network, label: 'Org Chart' },
           { to: '/admin/assets', icon: Package, label: 'Assets' },
           { to: '/admin/leases', icon: FileText, label: 'Leases' },
           { to: '/admin/groups', icon: Shield, label: 'Access Groups' },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -682,6 +682,20 @@ export const analyticsApi = {
     api.get<{ data: FloorUtilisationPoint[] }>(`/analytics/floor-utilisation${analyticsQs(params)}`),
   departments: (params?: AnalyticsParams) =>
     api.get<{ data: DepartmentAnalyticsPoint[] }>(`/analytics/departments${analyticsQs(params)}`),
+  managerRollup: (userId: string, params?: AnalyticsParams) => {
+    const qs = analyticsQs(params)
+    const sep = qs ? '&' : '?'
+    return api.get<{ data: ManagerRollup }>(`/analytics/manager-rollup${qs}${sep}userId=${encodeURIComponent(userId)}`)
+  },
+}
+
+export type ManagerRollupBranch = { rootId: string; rootName: string; peopleCount: number; bookingCount: number; deskDays: number }
+export type ManagerRollup = {
+  manager: { id: string; displayName: string; email: string }
+  peopleCount: number
+  bookingCount: number
+  deskDays: number
+  directReports: ManagerRollupBranch[]
 }
 
 // --- Notifications ---
@@ -774,14 +788,11 @@ export const webhooksApi = {
     ),
 }
 
-// --- Departments ---
+// --- Departments (flat; hierarchy is inferred from manager links via orgApi) ---
 export interface Department {
   id: string
   name: string
-  parentId: string | null
-  parent?: { id: string; name: string } | null
-  children?: Array<{ id: string; name: string; _count: { members: number } }>
-  _count?: { members: number; children: number }
+  _count?: { members: number }
 }
 
 export interface DepartmentMember {
@@ -792,12 +803,35 @@ export interface DepartmentMember {
   accountStatus: string
 }
 
+// --- Org hierarchy (manager-derived) ---
+export interface OrgPerson {
+  id: string
+  displayName: string
+  email: string
+  departmentId: string | null
+  managerId: string | null
+}
+export interface OrgDepartment {
+  id: string
+  name: string
+  memberCount: number
+  inferredParentId: string | null
+}
+export interface OrgHierarchy {
+  people: OrgPerson[]
+  departments: OrgDepartment[]
+  unresolvedManagers: number
+}
+export const orgApi = {
+  hierarchy: () => api.get<{ data: OrgHierarchy }>('/org/hierarchy'),
+}
+
 export const departmentsApi = {
   list: () => api.get<{ data: Department[] }>('/departments'),
   get: (id: string) => api.get<{ data: Department }>(`/departments/${id}`),
-  create: (body: { name: string; parentId?: string }) =>
+  create: (body: { name: string }) =>
     api.post<{ data: Department }>('/departments', body),
-  update: (id: string, body: { name?: string; parentId?: string | null }) =>
+  update: (id: string, body: { name?: string }) =>
     api.put<{ data: Department }>(`/departments/${id}`, body),
   delete: (id: string) => api.delete<{ data: { ok: true } }>(`/departments/${id}`),
   listMembers: (id: string, search?: string) =>

--- a/apps/web/src/pages/admin/DepartmentsAdminPage.tsx
+++ b/apps/web/src/pages/admin/DepartmentsAdminPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { Network, Plus, Trash2, Users, ChevronRight } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { Network, Plus, Trash2, Users, Info } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { departmentsApi, usersApi, type Department, type DepartmentMember } from '@/lib/api'
 import { toast } from 'sonner'
@@ -9,10 +10,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Separator } from '@/components/ui/separator'
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from '@/components/ui/select'
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
 } from '@/components/ui/dialog'
@@ -26,28 +23,17 @@ import {
 
 // ─── Create Dialog ────────────────────────────────────────────────────────────
 
-function CreateDepartmentDialog({
-  open,
-  onClose,
-  departments,
-}: {
-  open: boolean
-  onClose: () => void
-  departments: Department[]
-}) {
+function CreateDepartmentDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const qc = useQueryClient()
   const [name, setName] = useState('')
-  const [parentId, setParentId] = useState<string>('none')
 
   const create = useMutation({
-    mutationFn: () =>
-      departmentsApi.create({ name, ...(parentId !== 'none' ? { parentId } : {}) }),
+    mutationFn: () => departmentsApi.create({ name }),
     onSuccess: () => {
       toast.success('Department created')
       qc.invalidateQueries({ queryKey: ['departments'] })
       onClose()
       setName('')
-      setParentId('none')
     },
     onError: () => toast.error('Failed to create department'),
   })
@@ -61,27 +47,7 @@ function CreateDepartmentDialog({
         <div className="space-y-4 py-1">
           <div>
             <Label htmlFor="dname">Name *</Label>
-            <Input
-              id="dname"
-              className="mt-1.5"
-              placeholder="e.g. Engineering"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-          <div>
-            <Label htmlFor="dparent">Parent department</Label>
-            <Select value={parentId} onValueChange={setParentId}>
-              <SelectTrigger id="dparent" className="mt-1.5">
-                <SelectValue placeholder="None (top-level)" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">None (top-level)</SelectItem>
-                {departments.map((d) => (
-                  <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Input id="dname" className="mt-1.5" placeholder="e.g. Engineering" value={name} onChange={(e) => setName(e.target.value)} />
           </div>
         </div>
         <DialogFooter>
@@ -97,27 +63,11 @@ function CreateDepartmentDialog({
 
 // ─── Detail Sheet ─────────────────────────────────────────────────────────────
 
-function DepartmentDetailSheet({
-  department,
-  allDepartments,
-  onClose,
-}: {
-  department: Department | null
-  allDepartments: Department[]
-  onClose: () => void
-}) {
+function DepartmentDetailSheet({ department, onClose }: { department: Department | null; onClose: () => void }) {
   const qc = useQueryClient()
   const [memberSearch, setMemberSearch] = useState('')
   const [selectedMemberId, setSelectedMemberId] = useState('')
   const [editName, setEditName] = useState<string | null>(null)
-  const [editParentId, setEditParentId] = useState<string>('none')
-
-  const { data: detail } = useQuery({
-    queryKey: ['departments', department?.id],
-    queryFn: () => departmentsApi.get(department!.id),
-    select: (r) => r.data,
-    enabled: !!department,
-  })
 
   const { data: members = [] } = useQuery({
     queryKey: ['departments', department?.id, 'members'],
@@ -134,8 +84,7 @@ function DepartmentDetailSheet({
   })
 
   const updateDept = useMutation({
-    mutationFn: (body: { name?: string; parentId?: string | null }) =>
-      departmentsApi.update(department!.id, body),
+    mutationFn: (name: string) => departmentsApi.update(department!.id, { name }),
     onSuccess: () => {
       toast.success('Department updated')
       qc.invalidateQueries({ queryKey: ['departments'] })
@@ -149,6 +98,7 @@ function DepartmentDetailSheet({
     onSuccess: () => {
       toast.success('Member added')
       qc.invalidateQueries({ queryKey: ['departments', department?.id, 'members'] })
+      qc.invalidateQueries({ queryKey: ['departments'] })
       setMemberSearch('')
       setSelectedMemberId('')
     },
@@ -160,29 +110,10 @@ function DepartmentDetailSheet({
     onSuccess: () => {
       toast.success('Member removed')
       qc.invalidateQueries({ queryKey: ['departments', department?.id, 'members'] })
+      qc.invalidateQueries({ queryKey: ['departments'] })
     },
     onError: () => toast.error('Failed to remove member'),
   })
-
-  const children = detail?.children ?? []
-  // Exclude self and own children from parent options to avoid cycles
-  const parentOptions = allDepartments.filter(
-    (d) => d.id !== department?.id && !children.some((c) => c.id === d.id),
-  )
-
-  function startEdit() {
-    if (!department) return
-    setEditName(department.name)
-    setEditParentId(department.parentId ?? 'none')
-  }
-
-  function saveEdit() {
-    if (editName === null) return
-    updateDept.mutate({
-      name: editName.trim() || undefined,
-      parentId: editParentId === 'none' ? null : editParentId,
-    })
-  }
 
   return (
     <Sheet open={!!department} onOpenChange={(o) => !o && onClose()}>
@@ -194,47 +125,21 @@ function DepartmentDetailSheet({
                 <Network className="h-5 w-5 text-primary" />
                 {department.name}
               </SheetTitle>
-              {department.parent && (
-                <p className="text-sm text-muted-foreground flex items-center gap-1">
-                  <ChevronRight className="h-3.5 w-3.5" />
-                  {department.parent.name}
-                </p>
-              )}
             </SheetHeader>
 
             <div className="mt-6 space-y-6">
-              {/* Edit name / parent */}
               <div>
                 <p className="text-sm font-semibold mb-2">Details</p>
                 {editName === null ? (
-                  <Button variant="outline" size="sm" onClick={startEdit}>Edit name / parent</Button>
+                  <Button variant="outline" size="sm" onClick={() => setEditName(department.name)}>Rename</Button>
                 ) : (
                   <div className="space-y-3">
                     <div>
                       <Label htmlFor="edit-name">Name</Label>
-                      <Input
-                        id="edit-name"
-                        className="mt-1.5"
-                        value={editName}
-                        onChange={(e) => setEditName(e.target.value)}
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="edit-parent">Parent department</Label>
-                      <Select value={editParentId} onValueChange={setEditParentId}>
-                        <SelectTrigger id="edit-parent" className="mt-1.5">
-                          <SelectValue placeholder="None (top-level)" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="none">None (top-level)</SelectItem>
-                          {parentOptions.map((d) => (
-                            <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <Input id="edit-name" className="mt-1.5" value={editName} onChange={(e) => setEditName(e.target.value)} />
                     </div>
                     <div className="flex gap-2">
-                      <Button size="sm" onClick={saveEdit} disabled={!editName.trim() || updateDept.isPending}>
+                      <Button size="sm" onClick={() => editName && updateDept.mutate(editName.trim())} disabled={!editName.trim() || updateDept.isPending}>
                         {updateDept.isPending ? 'Saving…' : 'Save'}
                       </Button>
                       <Button variant="ghost" size="sm" onClick={() => setEditName(null)}>Cancel</Button>
@@ -243,30 +148,6 @@ function DepartmentDetailSheet({
                 )}
               </div>
 
-              {/* Sub-departments */}
-              {children.length > 0 && (
-                <>
-                  <Separator />
-                  <div>
-                    <p className="text-sm font-semibold mb-3">Sub-departments ({children.length})</p>
-                    <div className="space-y-1.5">
-                      {children.map((child) => (
-                        <div key={child.id} className="flex items-center justify-between rounded-md border px-3 py-2">
-                          <p className="text-sm font-medium">{child.name}</p>
-                          <Badge variant="secondary" className="text-xs">
-                            <Users className="h-3 w-3 mr-1" />
-                            {child._count.members}
-                          </Badge>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </>
-              )}
-
-              <Separator />
-
-              {/* Members */}
               <div>
                 <p className="text-sm font-semibold mb-3 flex items-center gap-1.5">
                   <Users className="h-3.5 w-3.5" />
@@ -298,12 +179,7 @@ function DepartmentDetailSheet({
                     </div>
                   )}
                   {selectedMemberId && (
-                    <Button
-                      size="sm"
-                      className="mt-1.5 w-full"
-                      onClick={() => addMember.mutate()}
-                      disabled={addMember.isPending}
-                    >
+                    <Button size="sm" className="mt-1.5 w-full" onClick={() => addMember.mutate()} disabled={addMember.isPending}>
                       {addMember.isPending ? 'Adding…' : 'Add to department'}
                     </Button>
                   )}
@@ -363,17 +239,19 @@ export default function DepartmentsAdminPage() {
     onError: () => toast.error('Failed to delete department'),
   })
 
-  // Group into top-level and children for display
-  const topLevel = departments.filter((d) => !d.parentId)
-  const childDepts = departments.filter((d) => !!d.parentId)
-
   return (
     <div className="p-6 max-w-4xl mx-auto">
-      <div className="mb-6">
+      <div className="mb-4">
         <h1 className="text-2xl font-bold">Departments</h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          Manage organisational departments and their members
-        </p>
+        <p className="text-muted-foreground text-sm mt-1">Flat groupings of users, mapped from your identity provider.</p>
+      </div>
+
+      <div className="mb-5 flex items-start gap-2 rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+        <Info className="h-4 w-4 shrink-0 mt-0.5" />
+        <span>
+          Departments are no longer nested. The reporting hierarchy is inferred automatically from each user's manager —
+          see the <Link to="/admin/org-chart" className="font-medium text-foreground underline">Org Chart</Link>.
+        </span>
       </div>
 
       <div className="flex items-center justify-between mb-5">
@@ -386,110 +264,58 @@ export default function DepartmentsAdminPage() {
       </div>
 
       {isLoading ? (
-        <div className="space-y-3">{[1, 2, 3].map((i) => <Skeleton key={i} className="h-24 w-full" />)}</div>
+        <div className="space-y-3">{[1, 2, 3].map((i) => <Skeleton key={i} className="h-20 w-full" />)}</div>
       ) : departments.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <Network className="h-12 w-12 text-muted-foreground/30 mb-3" />
           <p className="text-sm text-muted-foreground">No departments yet</p>
-          <p className="text-xs text-muted-foreground mt-1">
-            Departments let you organise users into teams and track usage by group
-          </p>
           <Button variant="outline" size="sm" className="mt-3" onClick={() => setCreateOpen(true)}>
             Create first department
           </Button>
         </div>
       ) : (
-        <div className="space-y-6">
-          {/* Top-level departments */}
-          <div className="grid gap-3 sm:grid-cols-2">
-            {topLevel.map((dept) => {
-              const ownChildren = childDepts.filter((c) => c.parentId === dept.id)
-              return (
-                <Card
-                  key={dept.id}
-                  className="hover:shadow-md transition-shadow cursor-pointer"
-                  onClick={() => setSelectedDept(dept)}
-                >
-                  <CardHeader className="pb-2">
-                    <div className="flex items-start justify-between">
-                      <CardTitle className="text-base">{dept.name}</CardTitle>
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7 hover:text-destructive -mt-1 -mr-1"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Delete department?</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              Delete <strong>{dept.name}</strong>? Members will be unassigned and sub-departments will become top-level.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={() => deleteDept.mutate(dept.id)}
-                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                            >
-                              Delete
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="pt-0">
-                    <div className="flex flex-wrap gap-1.5">
-                      <Badge variant="secondary" className="text-xs">
-                        <Users className="h-3 w-3 mr-1" />
-                        {dept._count?.members ?? 0} member{(dept._count?.members ?? 0) !== 1 ? 's' : ''}
-                      </Badge>
-                      {ownChildren.length > 0 && (
-                        <Badge variant="outline" className="text-xs">
-                          <Network className="h-3 w-3 mr-1" />
-                          {ownChildren.length} sub-dept{ownChildren.length !== 1 ? 's' : ''}
-                        </Badge>
-                      )}
-                    </div>
-                    {/* Sub-departments inline */}
-                    {ownChildren.length > 0 && (
-                      <div className="mt-2 space-y-1">
-                        {ownChildren.map((child) => (
-                          <div
-                            key={child.id}
-                            className="flex items-center gap-1.5 text-xs text-muted-foreground"
-                          >
-                            <ChevronRight className="h-3 w-3 shrink-0" />
-                            <span>{child.name}</span>
-                            <span className="ml-auto">{child._count?.members ?? 0} members</span>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              )
-            })}
-          </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {departments.map((dept) => (
+            <Card key={dept.id} className="hover:shadow-md transition-shadow cursor-pointer" onClick={() => setSelectedDept(dept)}>
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between">
+                  <CardTitle className="text-base">{dept.name}</CardTitle>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-7 w-7 hover:text-destructive -mt-1 -mr-1" onClick={(e) => e.stopPropagation()}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete department?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Delete <strong>{dept.name}</strong>? Members will be unassigned.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => deleteDept.mutate(dept.id)} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <Badge variant="secondary" className="text-xs">
+                  <Users className="h-3 w-3 mr-1" />
+                  {dept._count?.members ?? 0} member{(dept._count?.members ?? 0) !== 1 ? 's' : ''}
+                </Badge>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       )}
 
-      <CreateDepartmentDialog
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
-        departments={departments}
-      />
-      <DepartmentDetailSheet
-        department={selectedDept}
-        allDepartments={departments}
-        onClose={() => setSelectedDept(null)}
-      />
+      <CreateDepartmentDialog open={createOpen} onClose={() => setCreateOpen(false)} />
+      <DepartmentDetailSheet department={selectedDept} onClose={() => setSelectedDept(null)} />
     </div>
   )
 }

--- a/apps/web/src/pages/admin/OrgChartPage.tsx
+++ b/apps/web/src/pages/admin/OrgChartPage.tsx
@@ -1,0 +1,86 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Network, Info } from 'lucide-react'
+import { orgApi } from '@/lib/api'
+import { OrgChartCanvas, type OrgNode } from '@/components/org/OrgChartCanvas'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function OrgChartPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['org', 'hierarchy'],
+    queryFn: () => orgApi.hierarchy(),
+    select: (r) => r.data,
+  })
+
+  const [selectedPerson, setSelectedPerson] = useState<string | null>(null)
+  const [selectedDept, setSelectedDept] = useState<string | null>(null)
+
+  const deptName = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const d of data?.departments ?? []) m.set(d.id, d.name)
+    return m
+  }, [data])
+
+  const peopleNodes: OrgNode[] = useMemo(
+    () => (data?.people ?? []).map((p) => ({
+      id: p.id,
+      label: p.displayName,
+      sublabel: p.departmentId ? deptName.get(p.departmentId) : undefined,
+      parentId: p.managerId,
+    })),
+    [data, deptName],
+  )
+
+  const deptNodes: OrgNode[] = useMemo(
+    () => (data?.departments ?? []).map((d) => ({
+      id: d.id,
+      label: d.name,
+      sublabel: `${d.memberCount} ${d.memberCount === 1 ? 'person' : 'people'}`,
+      parentId: d.inferredParentId,
+    })),
+    [data],
+  )
+
+  const totalPeople = data?.people.length ?? 0
+  const resolved = totalPeople - (data?.unresolvedManagers ?? 0)
+
+  return (
+    <div className="p-6">
+      <div className="mb-1 flex items-center gap-2">
+        <Network className="h-5 w-5 text-primary" />
+        <h1 className="text-2xl font-bold">Org chart</h1>
+      </div>
+      <p className="text-sm text-muted-foreground mb-4">
+        Hierarchy inferred from each user's manager (synced from your identity provider). Departments on the right are derived from where their people report.
+      </p>
+
+      {data && data.unresolvedManagers > 0 && (
+        <div className="mb-4 flex items-start gap-2 rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+          <Info className="h-4 w-4 shrink-0 mt-0.5" />
+          <span>
+            {resolved} of {totalPeople} users have a resolved manager. The rest appear as top-level nodes — configure the manager attribute/claim for your provider and run a sync to link them.
+          </span>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Skeleton className="h-[560px] w-full" />
+          <Skeleton className="h-[560px] w-full" />
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div>
+            <p className="text-sm font-medium mb-1.5">People</p>
+            <OrgChartCanvas nodes={peopleNodes} highlightId={selectedPerson} onSelect={setSelectedPerson} accent="#6366f1" />
+          </div>
+          <div>
+            <p className="text-sm font-medium mb-1.5">Departments</p>
+            <OrgChartCanvas nodes={deptNodes} highlightId={selectedDept} onSelect={setSelectedDept} accent="#0ea5e9" />
+          </div>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground mt-2">Scroll to zoom · drag to pan · click a node to highlight.</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/ReportsAdminPage.tsx
+++ b/apps/web/src/pages/admin/ReportsAdminPage.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import {
   analyticsApi,
   buildingsApi,
+  usersApi,
   type AnalyticsParams,
   type StatusBreakdownPoint,
   type PeakDayPoint,
@@ -549,6 +550,89 @@ function DepartmentAnalyticsTable({ params }: { params: AnalyticsParams }) {
   )
 }
 
+// ─── Manager roll-up ──────────────────────────────────────────────────────────
+
+function ManagerRollupCard({ params }: { params: AnalyticsParams }) {
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<{ id: string; displayName: string } | null>(null)
+
+  const { data: results } = useQuery({
+    queryKey: ['users', 'search', search],
+    queryFn: () => usersApi.list({ q: search, limit: 10 }),
+    select: (r) => r.data,
+    enabled: search.length >= 2 && !selected,
+  })
+
+  const { data: rollup, isLoading } = useQuery({
+    queryKey: ['analytics', 'manager-rollup', selected?.id, params],
+    queryFn: () => analyticsApi.managerRollup(selected!.id, params),
+    select: (r) => r.data,
+    enabled: !!selected,
+  })
+
+  return (
+    <Card className="col-span-2">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Manager roll-up</CardTitle>
+        <CardDescription className="text-xs">Bookings &amp; desk-days across a manager's entire reporting line</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="relative max-w-sm">
+          <Input
+            placeholder="Search for a manager…"
+            value={selected ? selected.displayName : search}
+            onChange={(e) => { setSelected(null); setSearch(e.target.value) }}
+            className="text-sm"
+          />
+          {!selected && results && results.length > 0 && (
+            <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover divide-y max-h-48 overflow-y-auto shadow-md">
+              {results.map((u) => (
+                <button key={u.id} type="button" className="w-full text-left px-3 py-1.5 hover:bg-muted text-sm" onClick={() => { setSelected({ id: u.id, displayName: u.displayName }); setSearch('') }}>
+                  <p className="font-medium">{u.displayName}</p>
+                  <p className="text-xs text-muted-foreground">{u.email}</p>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {selected && isLoading && <div className="mt-4"><Skeleton className="h-24 w-full" /></div>}
+        {selected && rollup && (
+          <div className="mt-4 space-y-4">
+            <div className="grid grid-cols-3 gap-3">
+              <div className="rounded-md border p-3"><p className="text-xs text-muted-foreground">People (incl. self)</p><p className="text-xl font-semibold tabular-nums">{rollup.peopleCount}</p></div>
+              <div className="rounded-md border p-3"><p className="text-xs text-muted-foreground">Bookings</p><p className="text-xl font-semibold tabular-nums">{rollup.bookingCount}</p></div>
+              <div className="rounded-md border p-3"><p className="text-xs text-muted-foreground">Desk-days</p><p className="text-xl font-semibold tabular-nums">{rollup.deskDays}</p></div>
+            </div>
+            {rollup.directReports.length > 0 && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead><tr className="border-b bg-muted/40">
+                    <th className="text-left px-4 py-2 text-xs font-medium text-muted-foreground">Direct report (sub-org)</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">People</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">Bookings</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">Desk-days</th>
+                  </tr></thead>
+                  <tbody className="divide-y">
+                    {rollup.directReports.map((b) => (
+                      <tr key={b.rootId} className="hover:bg-muted/30">
+                        <td className="px-4 py-2 font-medium">{b.rootName}</td>
+                        <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">{b.peopleCount}</td>
+                        <td className="px-4 py-2 text-right tabular-nums">{b.bookingCount}</td>
+                        <td className="px-4 py-2 text-right tabular-nums font-medium">{b.deskDays}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
 // ─── Export All ───────────────────────────────────────────────────────────────
 
 function ExportAllButton({ params, days }: { params: AnalyticsParams; days: Preset }) {
@@ -742,6 +826,7 @@ export default function ReportsAdminPage() {
         <FloorUtilisationChart params={params} />
         <ZoneUtilisationTable params={params} />
         <DepartmentAnalyticsTable params={params} />
+        <ManagerRollupCard params={params} />
       </div>
     </div>
   )

--- a/apps/web/src/pages/admin/SettingsAdminPage.tsx
+++ b/apps/web/src/pages/admin/SettingsAdminPage.tsx
@@ -664,13 +664,14 @@ function OidcConfigForm({
   const [label, setLabel] = useState((current.label as string) ?? 'Sign in with SSO')
   const [groupsClaimName, setGroupsClaimName] = useState((current.groupsClaimName as string) ?? 'groups')
   const [departmentClaimName, setDepartmentClaimName] = useState((current.departmentClaimName as string) ?? '')
+  const [managerClaimName, setManagerClaimName] = useState((current.managerClaimName as string) ?? '')
   const [groupMappings, setGroupMappings] = useState<GroupMapping[]>(
     (current.groupMappings as GroupMapping[]) ?? [],
   )
 
   function handleSave() {
     const cfg: Record<string, unknown> = {
-      issuerUrl, clientId, redirectUri, scope, label, groupsClaimName, departmentClaimName, groupMappings,
+      issuerUrl, clientId, redirectUri, scope, label, groupsClaimName, departmentClaimName, managerClaimName, groupMappings,
     }
     if (clientSecret) cfg.clientSecret = clientSecret
     onSave(cfg)
@@ -718,6 +719,11 @@ function OidcConfigForm({
           <Input value={departmentClaimName} onChange={(e) => setDepartmentClaimName(e.target.value)}
             className="mt-1 h-8 text-sm" placeholder="department" />
         </div>
+        <div>
+          <Label className="text-xs">Manager claim name <span className="text-muted-foreground font-normal">(optional)</span></Label>
+          <Input value={managerClaimName} onChange={(e) => setManagerClaimName(e.target.value)}
+            className="mt-1 h-8 text-sm" placeholder="manager (email/UPN)" />
+        </div>
       </div>
       <Separator />
       <GroupMappingsEditor mappings={groupMappings} onChange={setGroupMappings} provider="OIDC" />
@@ -748,6 +754,7 @@ function SamlConfigForm({
   const [label, setLabel] = useState((current.label as string) ?? 'Sign in with SAML SSO')
   const [groupAttribute, setGroupAttribute] = useState((current.groupAttribute as string) ?? 'groups')
   const [departmentAttribute, setDepartmentAttribute] = useState((current.departmentAttribute as string) ?? '')
+  const [managerAttribute, setManagerAttribute] = useState((current.managerAttribute as string) ?? '')
   const [groupMappings, setGroupMappings] = useState<GroupMapping[]>(
     (current.groupMappings as GroupMapping[]) ?? [],
   )
@@ -764,6 +771,7 @@ function SamlConfigForm({
   function handleSave() {
     const cfg: Record<string, unknown> = { entryPoint, issuer, cert, callbackUrl, label, groupAttribute, groupMappings, wantAuthnResponseSigned, wantAssertionsSigned, allowClockSkewMs }
     if (departmentAttribute.trim()) cfg.departmentAttribute = departmentAttribute.trim()
+    if (managerAttribute.trim()) cfg.managerAttribute = managerAttribute.trim()
     onSave(cfg)
   }
 
@@ -800,6 +808,12 @@ function SamlConfigForm({
           <Input value={departmentAttribute} onChange={(e) => setDepartmentAttribute(e.target.value)}
             className="mt-1 h-8 text-sm" placeholder="department" />
           <p className="text-[11px] text-muted-foreground mt-1">Maps to Roomer departments on login. Falls back to the Microsoft identity claim if blank.</p>
+        </div>
+        <div>
+          <Label className="text-xs">Manager attribute name <span className="text-muted-foreground font-normal">(optional)</span></Label>
+          <Input value={managerAttribute} onChange={(e) => setManagerAttribute(e.target.value)}
+            className="mt-1 h-8 text-sm" placeholder="manager (email/UPN)" />
+          <p className="text-[11px] text-muted-foreground mt-1">Builds the org chart. Falls back to the Microsoft manager claim if blank.</p>
         </div>
         <div className="sm:col-span-2">
           <Label className="text-xs">IdP Certificate (PEM, without headers)</Label>
@@ -937,6 +951,9 @@ function LdapConfigForm({
   const [departmentAttribute, setDepartmentAttribute] = useState(
     (current.departmentAttribute as string) ?? '',
   )
+  const [managerAttribute, setManagerAttribute] = useState(
+    (current.managerAttribute as string) ?? '',
+  )
   const [tlsEnabled, setTlsEnabled] = useState((current.tlsEnabled as boolean) ?? false)
   const [tlsRejectUnauthorized, setTlsRejectUnauthorized] = useState(
     (current.tlsRejectUnauthorized as boolean) ?? true,
@@ -982,6 +999,7 @@ function LdapConfigForm({
     if (bindCredentials) cfg.bindCredentials = bindCredentials
     cfg.syncBase = syncBase.trim() || null
     if (departmentAttribute.trim()) cfg.departmentAttribute = departmentAttribute.trim()
+    if (managerAttribute.trim()) cfg.managerAttribute = managerAttribute.trim()
     onSave(cfg)
   }
 
@@ -1077,6 +1095,12 @@ function LdapConfigForm({
           <Input value={departmentAttribute} onChange={(e) => setDepartmentAttribute(e.target.value)}
             className="mt-1 h-8 text-sm" placeholder="department" />
           <p className="text-[11px] text-muted-foreground mt-1">Syncs the user's department on login and during directory sync.</p>
+        </div>
+        <div>
+          <Label className="text-xs">Manager attribute <span className="text-muted-foreground font-normal">(optional)</span></Label>
+          <Input value={managerAttribute} onChange={(e) => setManagerAttribute(e.target.value)}
+            className="mt-1 h-8 text-sm" placeholder="manager" />
+          <p className="text-[11px] text-muted-foreground mt-1">The DN attribute pointing to the user's manager (e.g. <code>manager</code>). Builds the org chart on sync.</p>
         </div>
 
         <Separator className="sm:col-span-2" />

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -25,6 +25,7 @@ import { Loader2 } from 'lucide-react'
 // Lazy-load pages that pull in large dependencies (pdfjs-dist, react-konva, recharts)
 // so they are excluded from the initial bundle.
 const FloorPage = lazy(() => import('./pages/FloorPage'))
+const OrgChartPage = lazy(() => import('./pages/admin/OrgChartPage'))
 const FloorAdminPage = lazy(() => import('./pages/admin/FloorAdminPage'))
 const ReportsAdminPage = lazy(() => import('./pages/admin/ReportsAdminPage'))
 
@@ -144,6 +145,7 @@ export function AppRouter() {
             <Route path="/admin/settings" element={<SettingsAdminPage />} />
             <Route path="/admin/groups" element={<GroupsAdminPage />} />
             <Route path="/admin/departments" element={<DepartmentsAdminPage />} />
+            <Route path="/admin/org-chart" element={<Suspense fallback={<PageLoader />}><OrgChartPage /></Suspense>} />
             <Route path="/admin/webhooks" element={<WebhooksAdminPage />} />
           </Route>
 

--- a/packages/shared/src/schemas/department.ts
+++ b/packages/shared/src/schemas/department.ts
@@ -2,12 +2,10 @@ import { z } from 'zod'
 
 export const createDepartmentSchema = z.object({
   name: z.string().min(1, 'Department name is required').max(255),
-  parentId: z.string().optional(),
 })
 
 export const updateDepartmentSchema = z.object({
   name: z.string().min(1).max(255).optional(),
-  parentId: z.string().nullable().optional(),
 })
 
 export type CreateDepartmentInput = z.infer<typeof createDepartmentSchema>


### PR DESCRIPTION
Reworks departments per the new direction: departments are **flat**, and the reporting hierarchy is **inferred from each user's manager** (synced from the IdP). Adds a side-by-side org-chart view and manager-based analytics.

## Decisions (confirmed)
- **Manager source:** all providers — LDAP `manager` DN + OIDC/SAML manager claim/attribute.
- **Graph:** Konva canvas (existing dep, no new libraries).
- **View:** people tree **and** department tree side by side.

## Data model
- `User.managerId` (self-relation) + `User.managerExternalRef` (raw IdP ref kept so forward references reconcile on later sync/login).
- `Department.parentId` **dropped** — departments are a flat IdP-mapped grouping; inter-department hierarchy is *derived* from manager edges.

## Manager capture & resolution (`lib/manager.ts`)
- **LDAP:** sync reads the `manager` DN, stores the ref, then `reconcileAllManagers()` resolves DN → user across the whole directory in one pass (handles DN whitespace + forward refs). Covers your 275 AD users on the next sync.
- **OIDC/SAML:** `managerClaimName` / `managerAttribute` captured on login; `resolveManagerForUser()` matches by externalId/email/UPN and also links any reports that referenced this user.

## APIs
- `GET /org/hierarchy` — people manager-tree + department tree inferred from where each department's people report (most-common cross-department manager → parent).
- `GET /analytics/manager-rollup?userId=` — bookings/desk-days for a manager's **entire reporting subtree** (recursive CTE) + per-direct-report breakdown.
- Department routes/schemas no longer accept `parentId`.

## Web
- **Org Chart page** (admin): side-by-side People + Departments trees on a Konva canvas with pan/zoom/auto-fit. Nav + route added.
- **Departments admin** flattened (rename + members only), with a pointer to the org chart.
- **Reports:** "Manager roll-up" card — search a manager → subtree totals + per-direct-report breakdown.
- Provider settings forms gain the manager attribute/claim field (LDAP/OIDC/SAML).

## To populate the hierarchy
Set the **LDAP `managerAttribute` = `manager`** (Settings → LDAP) and run a directory sync — managers resolve and the chart fills in. (Verified: `/org/hierarchy` returns all 288 users; managers show unresolved until that sync runs. No fake manager data was injected.)

## Migration
`20260607010000_manager_hierarchy` — adds the manager columns/FK, drops `Department.parentId`. **Applied to dev DB.** Apply with `prisma migrate deploy`.

## Test plan
- [x] `tsc` (shared/api/web), api+web lint — clean (0 errors)
- [x] Migration applied; `/org/hierarchy` returns people + departments
- [ ] Configure LDAP managerAttribute → sync → org chart shows the tree; manager roll-up aggregates a subtree
- [ ] OIDC/SAML login with a manager claim links the user