### PR TITLE
chore(web): cut lint warnings 171 → 56

### DIFF
--- a/apps/web/src/pages/admin/BuildingDetailAdminPage.tsx
+++ b/apps/web/src/pages/admin/BuildingDetailAdminPage.tsx
@@ -122,7 +122,7 @@ function FloorDialog({
   )
 }
 
-function FloorCard({ floor, buildingId }: { floor: Floor; buildingId: string }) {
+function FloorCard({ floor, buildingId }: { floor: Floor & { _count?: { zones: number } }; buildingId: string }) {
   const navigate = useNavigate()
   const qc = useQueryClient()
   const fileRef = useRef<HTMLInputElement>(null)
@@ -175,12 +175,12 @@ function FloorCard({ floor, buildingId }: { floor: Floor; buildingId: string }) 
               <div className="flex items-center gap-2 flex-wrap">
                 <p className="font-medium">{floor.name}</p>
                 <Badge variant="outline" className="text-xs">Level {floor.level}</Badge>
-                {(floor as any).floorPlan && (
+                {floor.floorPlan && (
                   <Badge variant="secondary" className="text-xs">Floor plan ✓</Badge>
                 )}
               </div>
               <p className="text-xs text-muted-foreground mt-0.5">
-                {(floor as any)._count?.zones ?? 0} zones
+                {floor._count?.zones ?? 0} zones
               </p>
             </div>
           </div>
@@ -198,7 +198,7 @@ function FloorCard({ floor, buildingId }: { floor: Floor; buildingId: string }) 
               onChange={(e) => {
                 const file = e.target.files?.[0]
                 if (!file) return
-                if ((floor as any).floorPlan) {
+                if (floor.floorPlan) {
                   setPendingUploadFile(file)
                   setReplaceConfirmOpen(true)
                 } else {

--- a/apps/web/src/pages/admin/FloorAdminPage.tsx
+++ b/apps/web/src/pages/admin/FloorAdminPage.tsx
@@ -1013,8 +1013,8 @@ export default function FloorAdminPage() {
     [updateTransform],
   )
 
-  const buildingId = (floor as any)?.building?.id
-  const buildingName = (floor as any)?.building?.name
+  const buildingId = floor?.building?.id
+  const buildingName = floor?.building?.name
   const zones: ZoneData[] = (floor?.zones ?? []) as ZoneData[]
   const totalDesks = zones.reduce((s, z) => s + (z.assets?.length ?? 0), 0)
 

--- a/apps/web/src/pages/admin/ReportsAdminPage.tsx
+++ b/apps/web/src/pages/admin/ReportsAdminPage.tsx
@@ -383,7 +383,7 @@ function ZoneUtilisationTable({ params }: { params: AnalyticsParams }) {
           <ExportBtn onClick={() => downloadCsv('zone-utilisation.csv', [
             ['Building', 'Floor', 'Zone', 'Total', 'Bookable', 'Assigned', 'Disabled', 'Bookings', 'Utilisation %'],
             ...(data as UtilisationDataPoint[]).map((d) => [
-              (d as any).buildingName ?? '', d.floorName, d.zoneName,
+              d.buildingName ?? '', d.floorName, d.zoneName,
               String(d.totalDesks), String(d.bookableDesks), String(d.assignedDesks), String(d.disabledDesks),
               String(d.bookingCount), String(d.utilisationPct),
             ]),

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -341,6 +341,8 @@ export interface FloorSubscription {
 export interface UtilisationDataPoint {
   floorId: string
   floorName: string
+  buildingId?: string
+  buildingName?: string
   zoneId: string
   zoneName: string
   totalDesks: number

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,8 +41,25 @@ export default tseslint.config(
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       // react-hooks/set-state-in-effect: pattern is valid in controlled sync effects
       'react-hooks/set-state-in-effect': 'off',
+      // @eslint-react/set-state-in-effect is the same rule under a different plugin —
+      // turn it off too, consistent with the decision above.
+      '@eslint-react/set-state-in-effect': 'off',
       // react-hooks/use-memo: non-inline callbacks are fine when extracted for readability
       'react-hooks/use-memo': 'off',
+      // react-hook-form's watch()/control are React-compatible; this rule is a
+      // known false positive against that library's API.
+      'react-hooks/incompatible-library': 'off',
+    },
+  },
+
+  // Vendored shadcn/ui primitives — keep them as generated upstream (React.forwardRef,
+  // variant consts colocated with the component) rather than forking 30+ files away
+  // from the source they're maintained against.
+  {
+    files: ['apps/web/src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      '@eslint-react/no-forward-ref': 'off',
+      'react-refresh/only-export-components': 'off',
     },
   },
 )


### PR DESCRIPTION
Reduces web lint warnings from **171 → 56 (−67%)** with no behaviour change. Typecheck and lint pass (0 errors).

## Config-level suppressions (defensible)
- **`components/ui/**` (vendored shadcn)** — disable `@eslint-react/no-forward-ref` + `react-refresh/only-export-components`. These are generated primitives following upstream's `React.forwardRef` + colocated-variant-const pattern; forking 30+ files away from their source is worse than the warning. **−60**
- **`react-hooks/incompatible-library`** — known false positive against react-hook-form's `watch()`/`control` API (the library is React-compatible). **−6**
- **`@eslint-react/set-state-in-effect`** — the same rule as `react-hooks/set-state-in-effect`, which the config *already* disables with a documented rationale ("pattern is valid in controlled sync effects"). Turned off the twin for consistency. **−41**

## Real fixes (no behaviour change)
- `BuildingDetailAdminPage`: dropped gratuitous `(floor as any)` casts — `floorPlan` is already on the `Floor` type; widened the prop with `_count`.
- `FloorAdminPage` / `ReportsAdminPage`: typed `building` access and added `buildingName`/`buildingId` to `UtilisationDataPoint`.

## Left as warnings on purpose (genuine signal — not suppressed)
| Rule | Count | Why kept |
|------|-------|----------|
| `@eslint-react/purity` | 11 | Real `new Date()` / `matchMedia` calls during render |
| `@eslint-react/exhaustive-deps` | 3 | Possible stale-closure bugs — need per-site judgement |
| `@eslint-react/no-array-index-key` | 24 | Mostly benign but fixable incrementally |
| `@eslint-react/use-state` | 13 | Lazy-init micro-perf suggestions |
| `@typescript-eslint/no-explicit-any` | 2 | In `UsersAdminPage` — these mask a real `'SUSPENDED'` vs `ACTIVE\|BLOCKED` status mismatch that deserves its own fix, not a lint pave-over |

## Test plan
- [x] `tsc --noEmit` (web) — clean
- [x] `eslint src` — 0 errors, 56 warnings (was 171)