### PR TITLE
feat(web): group admin nav + keyboard-only focus rings

### DIFF
--- a/apps/web/src/components/layout/navStyles/FloatingNav.tsx
+++ b/apps/web/src/components/layout/navStyles/FloatingNav.tsx
@@ -149,7 +149,10 @@ export function FloatingNav() {
   const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
   const initials = user?.displayName?.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
   const personalSection  = sections.find((s) => s.id === 'personal')
-  const secondarySection = sections.find((s) => s.id !== 'personal')
+  const secondarySections = sections.filter((s) => s.id !== 'personal')
+  // All admin groups share one float trigger ('admin'); the panel lists them as
+  // labelled sub-groups. Single-section roles keep their own label.
+  const secondaryLabel = secondarySections.length > 1 ? 'Admin' : secondarySections[0]?.label ?? ''
 
   // ── Utility float ─────────────────────────────────────────────────────────
 
@@ -258,7 +261,7 @@ export function FloatingNav() {
   }, [openPanel])
 
   const gripClass = 'cursor-grab active:cursor-grabbing select-none touch-none text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors'
-  const SecIcon = secondarySection?.items[0]?.icon
+  const SecIcon = secondarySections[0]?.items[0]?.icon
 
   return (
     <>
@@ -379,21 +382,21 @@ export function FloatingNav() {
           </button>
 
           {/* Secondary section trigger (Admin / Manager) */}
-          {secondarySection && SecIcon && (
+          {secondarySections.length > 0 && SecIcon && (
             <>
               <div style={{ transform: `rotate(${-rotation}deg)` }} className="mx-1 h-8 w-px bg-border/60" />
               <button
-                onClick={() => togglePanel(secondarySection.id as PanelId)}
+                onClick={() => togglePanel('admin')}
                 className={cn(
                   'flex items-center justify-center rounded-xl p-2 transition-all duration-150',
-                  openPanel === secondarySection.id
+                  openPanel === 'admin'
                     ? 'bg-primary text-primary-foreground shadow-sm'
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
                 )}
               >
                 <div style={{ transform: `rotate(${-rotation}deg)` }} className="flex flex-col items-center gap-0.5">
                   <SecIcon className="h-5 w-5" />
-                  <span className="text-[10px] font-medium leading-none">{secondarySection.label}</span>
+                  <span className="text-[10px] font-medium leading-none">{secondaryLabel}</span>
                 </div>
               </button>
             </>
@@ -416,10 +419,10 @@ export function FloatingNav() {
           {openPanel === 'buildings' && (
             <BuildingsPanel buildingsData={buildingsData} onClose={closePanel} dir={panelState.dir} />
           )}
-          {openPanel === (secondarySection?.id as PanelId) && secondarySection && (
+          {openPanel === 'admin' && secondarySections.length > 0 && (
             <SectionPanel
-              label={secondarySection.label ?? ''}
-              items={secondarySection.items}
+              label={secondaryLabel}
+              sections={secondarySections}
               onClose={closePanel}
               dir={panelState.dir}
             />
@@ -512,16 +515,17 @@ function BuildingsPanel({
 
 function SectionPanel({
   label,
-  items,
+  sections,
   onClose,
   dir,
 }: {
   label: string
-  items: Array<{ to: string; icon: React.ElementType; label: string }>
+  sections: Array<{ id: string; label?: string; items: Array<{ to: string; icon: React.ElementType; label: string }> }>
   onClose: () => void
   dir: PanelDir
 }) {
   const navigate = useNavigate()
+  const grouped = sections.length > 1
   return (
     <div className={cn(
       'w-52 rounded-2xl border border-border/60 bg-background/90 p-2 shadow-2xl backdrop-blur-xl duration-150',
@@ -533,15 +537,24 @@ function SectionPanel({
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
-      {items.map((item) => (
-        <button
-          key={item.to}
-          onClick={() => { navigate(item.to); onClose() }}
-          className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground hover:bg-accent transition-colors"
-        >
-          <item.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-          {item.label}
-        </button>
+      {sections.map((section, i) => (
+        <div key={section.id} className={cn(i > 0 && 'mt-1.5')}>
+          {grouped && section.label && (
+            <p className="px-2 pb-0.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
+              {section.label}
+            </p>
+          )}
+          {section.items.map((item) => (
+            <button
+              key={item.to}
+              onClick={() => { navigate(item.to); onClose() }}
+              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground hover:bg-accent transition-colors"
+            >
+              <item.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+              {item.label}
+            </button>
+          ))}
+        </div>
       ))}
     </div>
   )

--- a/apps/web/src/components/layout/navStyles/FloatingNav.tsx
+++ b/apps/web/src/components/layout/navStyles/FloatingNav.tsx
@@ -123,6 +123,9 @@ const panelSlide: Record<PanelDir, string> = {
   left:  'animate-in slide-in-from-right-2',
 }
 
+// Keyboard-only focus ring — no lingering outline after a mouse click.
+const NAV_FOCUS = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+
 // Compute the fixed anchor point for a panel given the pill's getBoundingClientRect
 function computeAnchor(dir: PanelDir, rect: DOMRect, gap = 8): Pos {
   switch (dir) {
@@ -350,6 +353,7 @@ export function FloatingNav() {
               className={({ isActive }) =>
                 cn(
                   'flex items-center justify-center rounded-xl p-2 transition-all duration-150',
+                  NAV_FOCUS,
                   isActive
                     ? 'bg-primary text-primary-foreground shadow-sm'
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
@@ -389,6 +393,7 @@ export function FloatingNav() {
                 onClick={() => togglePanel('admin')}
                 className={cn(
                   'flex items-center justify-center rounded-xl p-2 transition-all duration-150',
+                  NAV_FOCUS,
                   openPanel === 'admin'
                     ? 'bg-primary text-primary-foreground shadow-sm'
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',

--- a/apps/web/src/components/layout/navStyles/RailNav.tsx
+++ b/apps/web/src/components/layout/navStyles/RailNav.tsx
@@ -28,6 +28,9 @@ const APP_REPO_URL = import.meta.env.VITE_APP_REPO_URL || ''
 
 type RailSection = 'personal' | 'buildings' | 'admin' | 'manager' | null
 
+// Keyboard-only focus ring — no lingering outline after a mouse click.
+const NAV_FOCUS = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+
 export function RailNav({ onNavigate }: { onNavigate?: () => void }) {
   const { sections, buildingsData } = useNavConfig()
   const { user, logout } = useAuth()
@@ -250,6 +253,7 @@ function RailIcon({
           onClick={onClick}
           className={cn(
             'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
+            NAV_FOCUS,
             active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
           )}
         >

--- a/apps/web/src/components/layout/navStyles/RailNav.tsx
+++ b/apps/web/src/components/layout/navStyles/RailNav.tsx
@@ -43,7 +43,11 @@ export function RailNav({ onNavigate }: { onNavigate?: () => void }) {
   const initials = user?.displayName?.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
 
   const personalSection = sections.find((s) => s.id === 'personal')
-  const secondarySection = sections.find((s) => s.id !== 'personal')
+  const secondarySections = sections.filter((s) => s.id !== 'personal')
+  // All admin groups share one rail entry ('admin'); the flyout shows them as
+  // labelled sub-groups. Single-section roles keep their own label.
+  const secondaryLabel = secondarySections.length > 1 ? 'Admin' : secondarySections[0]?.label ?? 'More'
+  const secondaryIcon = secondarySections[0]?.items[0]?.icon
 
   useEffect(() => { setActivePanel(null) }, [location.pathname])
 
@@ -96,12 +100,12 @@ export function RailNav({ onNavigate }: { onNavigate?: () => void }) {
           />
 
           {/* Admin / Manager */}
-          {secondarySection && (
+          {secondarySections.length > 0 && secondaryIcon && (
             <RailIcon
-              icon={secondarySection.items[0].icon}
-              label={secondarySection.label ?? 'More'}
-              active={activePanel === (secondarySection.id as RailSection)}
-              onClick={() => toggle(secondarySection.id as RailSection)}
+              icon={secondaryIcon}
+              label={secondaryLabel}
+              active={activePanel === 'admin'}
+              onClick={() => toggle('admin')}
             />
           )}
 
@@ -146,7 +150,7 @@ export function RailNav({ onNavigate }: { onNavigate?: () => void }) {
               <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 {activePanel === 'personal' ? 'My Space' :
                  activePanel === 'buildings' ? 'Buildings' :
-                 secondarySection?.label}
+                 secondaryLabel}
               </span>
               <button onClick={() => setActivePanel(null)} className="rounded p-0.5 text-muted-foreground hover:text-foreground">
                 <X className="h-3.5 w-3.5" />
@@ -175,21 +179,30 @@ export function RailNav({ onNavigate }: { onNavigate?: () => void }) {
                 <BuildingsPanel buildingsData={buildingsData} onNavigate={handleNavigate} />
               )}
 
-              {activePanel === secondarySection?.id && secondarySection?.items.map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  onClick={handleNavigate}
-                  className={({ isActive }) =>
-                    cn(
-                      'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                      isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                    )
-                  }
-                >
-                  <item.icon className="h-4 w-4 shrink-0" />
-                  {item.label}
-                </NavLink>
+              {activePanel === 'admin' && secondarySections.map((section, i) => (
+                <div key={section.id} className={cn(i > 0 && 'pt-2')}>
+                  {secondarySections.length > 1 && section.label && (
+                    <p className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
+                      {section.label}
+                    </p>
+                  )}
+                  {section.items.map((item) => (
+                    <NavLink
+                      key={item.to}
+                      to={item.to}
+                      onClick={handleNavigate}
+                      className={({ isActive }) =>
+                        cn(
+                          'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                          isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                        )
+                      }
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {item.label}
+                    </NavLink>
+                  ))}
+                </div>
               ))}
             </nav>
           </div>

--- a/apps/web/src/components/layout/navStyles/SidebarNav.tsx
+++ b/apps/web/src/components/layout/navStyles/SidebarNav.tsx
@@ -135,6 +135,7 @@ function NavItemLink({
             className={({ isActive }) =>
               cn(
                 'flex items-center justify-center rounded-lg p-2 transition-colors',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
                 isActive
                   ? 'bg-primary/10 text-primary'
                   : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
@@ -156,6 +157,7 @@ function NavItemLink({
       className={({ isActive }) =>
         cn(
           'group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-150',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
           isActive
             ? 'bg-primary/10 text-primary'
             : 'text-muted-foreground hover:bg-accent/70 hover:text-foreground',

--- a/apps/web/src/components/layout/navStyles/TopNav.tsx
+++ b/apps/web/src/components/layout/navStyles/TopNav.tsx
@@ -39,7 +39,10 @@ export function TopNav() {
     ?.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
 
   const personalSection = sections.find((s) => s.id === 'personal')
-  const secondarySection = sections.find((s) => s.id !== 'personal')
+  const secondarySections = sections.filter((s) => s.id !== 'personal')
+  // Admin is split into several labelled groups; building-admin / floor-manager
+  // have a single section. Use a generic trigger when there's more than one group.
+  const secondaryTriggerLabel = secondarySections.length > 1 ? 'Admin' : secondarySections[0]?.label
 
   return (
     <>
@@ -82,21 +85,31 @@ export function TopNav() {
           {/* Buildings dropdown */}
           <BuildingsDropdown />
 
-          {/* Admin / Manager dropdown */}
-          {secondarySection && (
+          {/* Admin / Manager dropdown — groups rendered as labelled sections */}
+          {secondarySections.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap">
-                  {secondarySection.label}
+                  {secondaryTriggerLabel}
                   <ChevronDown className="h-3 w-3" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-48">
-                {secondarySection.items.map((item) => (
-                  <DropdownMenuItem key={item.to} onClick={() => navigate(item.to)}>
-                    <item.icon className="mr-2 h-4 w-4" />
-                    {item.label}
-                  </DropdownMenuItem>
+                {secondarySections.map((section, i) => (
+                  <div key={section.id}>
+                    {i > 0 && <DropdownMenuSeparator />}
+                    {secondarySections.length > 1 && section.label && (
+                      <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">
+                        {section.label}
+                      </DropdownMenuLabel>
+                    )}
+                    {section.items.map((item) => (
+                      <DropdownMenuItem key={item.to} onClick={() => navigate(item.to)}>
+                        <item.icon className="mr-2 h-4 w-4" />
+                        {item.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </div>
                 ))}
               </DropdownMenuContent>
             </DropdownMenu>

--- a/apps/web/src/components/layout/navStyles/TopNav.tsx
+++ b/apps/web/src/components/layout/navStyles/TopNav.tsx
@@ -25,6 +25,9 @@ import { buildingsApi } from '@/lib/api'
 const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'dev'
 const APP_REPO_URL = import.meta.env.VITE_APP_REPO_URL || ''
 
+// Keyboard-only focus ring — no lingering outline after a mouse click.
+const NAV_FOCUS = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+
 export function TopNav() {
   const { sections } = useNavConfig()
   const { user, logout } = useAuth()
@@ -71,6 +74,7 @@ export function TopNav() {
               className={({ isActive }) =>
                 cn(
                   'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors',
+                  NAV_FOCUS,
                   isActive
                     ? 'bg-primary text-primary-foreground'
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
@@ -89,7 +93,7 @@ export function TopNav() {
           {secondarySections.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap">
+                <button className={cn('flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap', NAV_FOCUS)}>
                   {secondaryTriggerLabel}
                   <ChevronDown className="h-3 w-3" />
                 </button>
@@ -201,7 +205,7 @@ function BuildingsDropdown() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap">
+        <button className={cn('flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors whitespace-nowrap', NAV_FOCUS)}>
           <Building2 className="h-3.5 w-3.5" />
           Buildings
           <ChevronDown className="h-3 w-3" />

--- a/apps/web/src/hooks/useNavConfig.ts
+++ b/apps/web/src/hooks/useNavConfig.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useAuthStore } from '@/stores/auth'
 import { useQuery } from '@tanstack/react-query'
 import { buildingsApi } from '@/lib/api'
-import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers, Network, Webhook, MapPin } from 'lucide-react'
+import { Calendar, Clock, Building2, Users, Settings, Package, BarChart3, FileText, Shield, Layers, Network, Workflow, Webhook, MapPin } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavItem {
@@ -79,22 +79,42 @@ export function useNavConfig() {
     ]
 
     if (isSuperAdmin) {
-      result.push({
-        id: 'admin',
-        label: 'Admin',
-        items: [
-          { to: '/admin/buildings', icon: Building2, label: 'Buildings' },
-          { to: '/admin/users', icon: Users, label: 'Users' },
-          { to: '/admin/departments', icon: Network, label: 'Departments' },
-          { to: '/admin/org-chart', icon: Network, label: 'Org Chart' },
-          { to: '/admin/assets', icon: Package, label: 'Assets' },
-          { to: '/admin/leases', icon: FileText, label: 'Leases' },
-          { to: '/admin/groups', icon: Shield, label: 'Access Groups' },
-          { to: '/admin/reports', icon: BarChart3, label: 'Reports' },
-          { to: '/admin/webhooks', icon: Webhook, label: 'Webhooks' },
-          { to: '/admin/settings', icon: Settings, label: 'Settings' },
-        ],
-      })
+      result.push(
+        {
+          id: 'admin-people',
+          label: 'People',
+          items: [
+            { to: '/admin/users', icon: Users, label: 'Users' },
+            { to: '/admin/departments', icon: Network, label: 'Departments' },
+            { to: '/admin/org-chart', icon: Workflow, label: 'Org Chart' },
+          ],
+        },
+        {
+          id: 'admin-workplace',
+          label: 'Workplace',
+          items: [
+            { to: '/admin/buildings', icon: Building2, label: 'Buildings' },
+            { to: '/admin/assets', icon: Package, label: 'Assets' },
+            { to: '/admin/leases', icon: FileText, label: 'Leases' },
+          ],
+        },
+        {
+          id: 'admin-insights',
+          label: 'Insights',
+          items: [
+            { to: '/admin/reports', icon: BarChart3, label: 'Reports' },
+          ],
+        },
+        {
+          id: 'admin-system',
+          label: 'System',
+          items: [
+            { to: '/admin/groups', icon: Shield, label: 'Access Groups' },
+            { to: '/admin/webhooks', icon: Webhook, label: 'Webhooks' },
+            { to: '/admin/settings', icon: Settings, label: 'Settings' },
+          ],
+        },
+      )
     } else if (isBuildingAdmin) {
       result.push({
         id: 'building-admin',


### PR DESCRIPTION
Reorganises the SUPER_ADMIN navigation from a flat 10-item list into logical groups, and fixes a lingering focus-outline across all four nav styles.

## Nav grouping
Splits the admin area into four labelled groups (single source of truth in `useNavConfig.ts`):

| Group | Items |
|-------|-------|
| **People** | Users · Departments · Org Chart |
| **Workplace** | Buildings · Assets · Leases |
| **Insights** | Reports |
| **System** | Access Groups · Webhooks · Settings |

- **Org Chart** gets its own icon (`Workflow`) — it previously shared `Network` with Departments.
- Building-admin / floor-manager roles are unchanged (single section, own label).

### Renderer changes (required, not just data)
`NavSection` already supports multiple labelled sections, but only `SidebarNav` iterated them — `TopNav` / `RailNav` / `FloatingNav` used `.find()` and would have shown **only the first group**, silently dropping Workplace/Insights/System. All three now render every secondary section as labelled sub-groups behind a single "Admin" entry point, preserving each style's idiom:
- **Sidebar** — inline group headers (already worked)
- **Top** — one "Admin" dropdown with group labels + separators
- **Rail** — one "Admin" rail icon → flyout with grouped sub-headers
- **Floating** — one "Admin" float → panel with grouped sub-headers (generalised `SectionPanel`)

## Focus-ring fix
Nav controls retained the browser default outline after a **mouse** click until focus moved. Switched to a keyboard-only `focus-visible` inset ring (themed via `--ring`) across all four styles, so the outline no longer lingers on click while keyboard a11y is preserved. Applied via a shared `NAV_FOCUS` constant to persistently-visible controls (flyout/dropdown items close on click, so they never linger).

## Test plan
- [x] `tsc --noEmit` (web) — clean
- [x] `eslint` on all changed files — 0 new warnings
- [x] Manually verified in dev: admin groups render correctly and the click-outline is gone (sidebar confirmed by reviewer; other styles share the same mechanism)