### PR TITLE
feat(assets): favourite assets (#90)

### DIFF
--- a/apps/api/prisma/migrations/20260609120000_favourite_assets/migration.sql
+++ b/apps/api/prisma/migrations/20260609120000_favourite_assets/migration.sql
@@ -1,0 +1,18 @@
+-- Favourite assets: a user's starred assets for quick access in the booking flow.
+
+CREATE TABLE "UserFavouriteAsset" (
+    "userId" TEXT NOT NULL,
+    "assetId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "UserFavouriteAsset_pkey" PRIMARY KEY ("userId","assetId")
+);
+
+CREATE INDEX "UserFavouriteAsset_userId_idx" ON "UserFavouriteAsset"("userId");
+CREATE INDEX "UserFavouriteAsset_assetId_idx" ON "UserFavouriteAsset"("assetId");
+
+ALTER TABLE "UserFavouriteAsset"
+    ADD CONSTRAINT "UserFavouriteAsset_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "UserFavouriteAsset"
+    ADD CONSTRAINT "UserFavouriteAsset_assetId_fkey"
+    FOREIGN KEY ("assetId") REFERENCES "Asset"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -360,11 +360,25 @@ model Asset {
   bookings              Booking[]
   queueEntries          QueueEntry[]
   recurringBookingRules RecurringBookingRule[]
+  favouritedBy          UserFavouriteAsset[]
 
   @@index([floorId])
   @@index([primaryZoneId])
   @@index([categoryId])
   @@index([isBookable])
+}
+
+/// A user's starred/favourite assets — quick access in the booking flow.
+model UserFavouriteAsset {
+  userId    String
+  assetId   String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  asset     Asset    @relation(fields: [assetId], references: [id], onDelete: Cascade)
+
+  @@id([userId, assetId])
+  @@index([userId])
+  @@index([assetId])
 }
 
 /// Availability window: a permanently assigned user can offer their asset for
@@ -478,6 +492,7 @@ model User {
   availabilityWindows   AssetAvailabilityWindow[] @relation("AvailabilityWindowOwner")
   floorSubscriptions    FloorSubscription[]
   recurringBookingRules RecurringBookingRule[]
+  favouriteAssets       UserFavouriteAsset[]
 
   @@index([email])
   @@index([provider, externalId])

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -462,6 +462,49 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(200).send({ data: assignments })
   })
 
+  // GET /assets/favourites — the current user's favourited bookable assets
+  // (registered before /:id so "favourites" is never captured as an id).
+  fastify.get('/favourites', { preHandler: [requireAuth] }, async (request, reply) => {
+    const favourites = await prisma.userFavouriteAsset.findMany({
+      where: { userId: request.user.id },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        asset: {
+          include: {
+            category: { select: { id: true, name: true } },
+            floor: {
+              select: { id: true, name: true, building: { select: { id: true, name: true } } },
+            },
+            primaryZone: { select: { id: true, name: true } },
+          },
+        },
+      },
+    })
+    return reply.status(200).send({ data: favourites.map((f) => f.asset) })
+  })
+
+  // POST /assets/:id/favourite — star an asset (idempotent)
+  fastify.post('/:id/favourite', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const asset = await prisma.asset.findUnique({ where: { id }, select: { id: true } })
+    if (!asset) {
+      return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+    }
+    await prisma.userFavouriteAsset.upsert({
+      where: { userId_assetId: { userId: request.user.id, assetId: id } },
+      create: { userId: request.user.id, assetId: id },
+      update: {},
+    })
+    return reply.status(200).send({ data: { ok: true, favourited: true } })
+  })
+
+  // DELETE /assets/:id/favourite — unstar an asset (idempotent)
+  fastify.delete('/:id/favourite', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    await prisma.userFavouriteAsset.deleteMany({ where: { userId: request.user.id, assetId: id } })
+    return reply.status(200).send({ data: { ok: true, favourited: false } })
+  })
+
   // POST /assets/:id/availability-windows — create an availability window
   fastify.post('/:id/availability-windows', { preHandler: [requireAuth] }, async (request, reply) => {
     const { id } = request.params as { id: string }

--- a/apps/web/src/components/floor-plan/DeskPanel.tsx
+++ b/apps/web/src/components/floor-plan/DeskPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { format, addHours, startOfDay, addDays } from 'date-fns'
 import { formatDateTime } from '@/lib/utils'
-import { MapPin, Clock, Users, CheckCircle, XCircle, AlertCircle, Shield, UserPlus, UserMinus, ChevronDown, ChevronUp, Pencil, X, Repeat } from 'lucide-react'
+import { MapPin, Clock, Users, CheckCircle, XCircle, AlertCircle, Shield, UserPlus, UserMinus, ChevronDown, ChevronUp, Pencil, X, Repeat, Star } from 'lucide-react'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -15,6 +15,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { useCreateBooking, useJoinQueue, useLeaveQueue, useClaimDesk, useCancelBooking, useMakeAvailable, useQueueEntries } from '@/hooks/useBookings'
+import { useFavourites } from '@/hooks/useFavourites'
+import { cn } from '@/lib/utils'
 import { formatDateRange } from '@/lib/utils'
 import { getDateFormat } from '@/lib/dateFormat'
 import { useAuthStore } from '@/stores/auth'
@@ -492,6 +494,7 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
   const cancelBooking = useCancelBooking()
   const makeAvailable = useMakeAvailable()
   const { data: queueEntries } = useQueueEntries()
+  const { isFavourite, toggleFavourite, isToggling } = useFavourites()
 
   const { data: allowList } = useQuery({
     queryKey: ['assets', desk?.id, 'allow-list'],
@@ -685,9 +688,21 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
                   <span>{desk.zoneName}</span>
                 </SheetDescription>
               </div>
-              <Badge variant={statusVariant[desk.bookingStatus]}>
-                {statusLabel[desk.bookingStatus]}
-              </Badge>
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => toggleFavourite(desk.id)}
+                  disabled={isToggling}
+                  title={isFavourite(desk.id) ? 'Remove from favourites' : 'Add to favourites'}
+                  aria-pressed={isFavourite(desk.id)}
+                  className="rounded-md p-1 text-muted-foreground transition-colors hover:text-amber-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <Star className={cn('h-4 w-4', isFavourite(desk.id) && 'fill-amber-400 text-amber-500')} />
+                </button>
+                <Badge variant={statusVariant[desk.bookingStatus]}>
+                  {statusLabel[desk.bookingStatus]}
+                </Badge>
+              </div>
             </div>
           </SheetHeader>
 

--- a/apps/web/src/hooks/useFavourites.ts
+++ b/apps/web/src/hooks/useFavourites.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { assetsApi } from '@/lib/api'
+
+const FAVOURITES_KEY = ['assets', 'favourites']
+
+/**
+ * Loads the current user's favourite assets and exposes a toggle.
+ * Shared between the booking flow (star on the desk panel) and the
+ * "My favourites" section on the assets page.
+ */
+export function useFavourites() {
+  const qc = useQueryClient()
+
+  const { data: favourites = [], isLoading } = useQuery({
+    queryKey: FAVOURITES_KEY,
+    queryFn: () => assetsApi.listFavourites(),
+    select: (r) => r.data,
+  })
+
+  const favouriteIds = useMemo(() => new Set(favourites.map((a) => a.id)), [favourites])
+
+  const toggle = useMutation({
+    mutationFn: ({ id, next }: { id: string; next: boolean }) =>
+      next ? assetsApi.addFavourite(id) : assetsApi.removeFavourite(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: FAVOURITES_KEY }),
+    onError: () => toast.error('Failed to update favourite'),
+  })
+
+  return {
+    favourites,
+    isLoading,
+    isFavourite: (id: string) => favouriteIds.has(id),
+    toggleFavourite: (id: string) => toggle.mutate({ id, next: !favouriteIds.has(id) }),
+    isToggling: toggle.isPending,
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -231,6 +231,12 @@ export interface MyAssignment {
   }
 }
 
+// A favourited asset enriched with its location (from GET /assets/favourites).
+export type FavouriteAsset = Asset & {
+  floor?: { id: string; name: string; building?: { id: string; name: string } | null } | null
+  primaryZone?: { id: string; name: string } | null
+}
+
 export const assetsApi = {
   list: () => api.get<{ data: Asset[] }>('/assets'),
   listCategories: () => api.get<{ data: AssetCategory[] }>('/assets/categories'),
@@ -345,6 +351,12 @@ export const assetsApi = {
     api.post<{ data: AvailabilityWindow }>(`/assets/${id}/availability-windows`, body),
   deleteAvailabilityWindow: (id: string, windowId: string) =>
     api.delete<{ data: { ok: true } }>(`/assets/${id}/availability-windows/${windowId}`),
+  // Favourites
+  listFavourites: () => api.get<{ data: FavouriteAsset[] }>('/assets/favourites'),
+  addFavourite: (id: string) =>
+    api.post<{ data: { ok: true; favourited: boolean } }>(`/assets/${id}/favourite`),
+  removeFavourite: (id: string) =>
+    api.delete<{ data: { ok: true; favourited: boolean } }>(`/assets/${id}/favourite`),
 }
 
 // --- Bookings ---

--- a/apps/web/src/pages/AssetsPage.tsx
+++ b/apps/web/src/pages/AssetsPage.tsx
@@ -1,6 +1,8 @@
-import { Package } from 'lucide-react'
+import { Package, Star, MapPin } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { assetsApi } from '@/lib/api'
+import { useFavourites } from '@/hooks/useFavourites'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -51,6 +53,52 @@ function AssetCard({ asset }: { asset: Asset }) {
   )
 }
 
+function FavouritesSection() {
+  const { favourites, isLoading, toggleFavourite, isToggling } = useFavourites()
+
+  if (isLoading || favourites.length === 0) return null
+
+  return (
+    <div className="mb-8">
+      <div className="mb-3 flex items-center gap-2">
+        <Star className="h-4 w-4 fill-amber-400 text-amber-500" />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">My favourites</h2>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {favourites.map((asset) => (
+          <Card key={asset.id}>
+            <CardContent className="p-4 flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="font-medium truncate">{asset.bookingLabel || asset.name}</p>
+                {(asset.floor?.building?.name || asset.floor?.name) && (
+                  <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground truncate">
+                    <MapPin className="h-3 w-3 shrink-0" />
+                    {[asset.floor?.building?.name, asset.floor?.name].filter(Boolean).join(' › ')}
+                  </p>
+                )}
+                {asset.floor?.id && (
+                  <Link to={`/floors/${asset.floor.id}`} className="mt-2 inline-block text-xs font-medium text-primary hover:underline">
+                    Book on floor plan →
+                  </Link>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => toggleFavourite(asset.id)}
+                disabled={isToggling}
+                title="Remove from favourites"
+                className="rounded-md p-1 text-amber-500 transition-colors hover:text-amber-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Star className="h-4 w-4 fill-amber-400" />
+              </button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export default function AssetsPage() {
   const { data, isLoading } = useQuery({
     queryKey: ['assets', 'my'],
@@ -64,6 +112,8 @@ export default function AssetsPage() {
         <h1 className="text-2xl font-bold">My Assets</h1>
         <p className="text-muted-foreground text-sm mt-1">Equipment and items assigned to you</p>
       </div>
+
+      <FavouritesSection />
 
       {isLoading ? (
         <div className="space-y-3">


### PR DESCRIPTION
Implements the **favourites** slice of #90 — star assets for quick access in the booking flow. (Smart booking *suggestions* remain as the follow-on, per the issue plan.)

## Backend
- **Schema:** `UserFavouriteAsset { userId, assetId, createdAt }` with a composite PK and indexes on both columns; cascade-deletes with the user/asset.
- **Migration:** `20260609120000_favourite_assets` (hand-written to match prior migrations; applied via `migrate deploy` to avoid resetting the dev DB over a pre-existing `sessions`-table drift).
- **API:** `GET /assets/favourites`, `POST /assets/:id/favourite`, `DELETE /assets/:id/favourite` (both idempotent). `GET /favourites` is registered **before** `/:id` so the literal isn't captured as an id.

## Frontend
- `useFavourites` hook (list + optimistic-ish toggle, shared).
- **Star toggle** in the desk booking panel header (`DeskPanel`).
- **"My favourites"** section on the assets page, each linking to the floor plan to book.

## Test plan
- [x] `tsc --noEmit` (api + web) — clean
- [x] `eslint` on changed files — clean
- [x] Migration applied to dev DB via `migrate deploy`
- [ ] Manual: star a desk → appears under My favourites → unstar removes it