### PR TITLE
feat(assets): recurring available days for assigned desks (#158)

### DIFF
--- a/apps/api/prisma/migrations/20260609130000_assigned_available_days/migration.sql
+++ b/apps/api/prisma/migrations/20260609130000_assigned_available_days/migration.sql
@@ -1,0 +1,22 @@
+-- Recurring weekday availability for permanently-assigned assets.
+-- An assigned user marks the weekdays their desk is always open to others.
+
+CREATE TABLE "AssetAvailabilityRule" (
+    "id" TEXT NOT NULL,
+    "assetId" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "weekday" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AssetAvailabilityRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AssetAvailabilityRule_assetId_weekday_key" ON "AssetAvailabilityRule"("assetId","weekday");
+CREATE INDEX "AssetAvailabilityRule_assetId_idx" ON "AssetAvailabilityRule"("assetId");
+CREATE INDEX "AssetAvailabilityRule_ownerId_idx" ON "AssetAvailabilityRule"("ownerId");
+
+ALTER TABLE "AssetAvailabilityRule"
+    ADD CONSTRAINT "AssetAvailabilityRule_assetId_fkey"
+    FOREIGN KEY ("assetId") REFERENCES "Asset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AssetAvailabilityRule"
+    ADD CONSTRAINT "AssetAvailabilityRule_ownerId_fkey"
+    FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -354,6 +354,7 @@ model Asset {
   allowList       AssetAllowList[]
   userAssignments       AssetUserAssignment[]
   availabilityWindows   AssetAvailabilityWindow[]
+  availabilityRules     AssetAvailabilityRule[]
   /// Temporary assignments (checked-out to a user with a return date).
   assignments     AssetAssignment[]
   /// Bookings made against this asset (only populated when isBookable=true).
@@ -381,6 +382,23 @@ model AssetAvailabilityWindow {
   owner     User     @relation("AvailabilityWindowOwner", fields: [ownerId], references: [id], onDelete: Cascade)
 
   @@index([assetId, startsAt, endsAt])
+  @@index([ownerId])
+}
+
+/// Recurring weekday availability: a permanently assigned user marks the
+/// weekdays their asset is always open to others (e.g. the days they work
+/// from home). Matched at booking time in assertBookable. weekday: 0=Sun..6=Sat.
+model AssetAvailabilityRule {
+  id        String   @id @default(cuid())
+  assetId   String
+  ownerId   String
+  weekday   Int
+  createdAt DateTime @default(now())
+  asset     Asset    @relation(fields: [assetId], references: [id], onDelete: Cascade)
+  owner     User     @relation("AvailabilityRuleOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+
+  @@unique([assetId, weekday])
+  @@index([assetId])
   @@index([ownerId])
 }
 
@@ -476,6 +494,7 @@ model User {
   groupMemberships     UserGroupMember[]
   assetUserAssignments AssetUserAssignment[]
   availabilityWindows   AssetAvailabilityWindow[] @relation("AvailabilityWindowOwner")
+  availabilityRules     AssetAvailabilityRule[]   @relation("AvailabilityRuleOwner")
   floorSubscriptions    FloorSubscription[]
   recurringBookingRules RecurringBookingRule[]
 

--- a/apps/api/src/lib/booking.ts
+++ b/apps/api/src/lib/booking.ts
@@ -86,6 +86,30 @@ function deny(status: number, code: string, message: string): BookabilityResult 
  * Note: this does NOT check time-slot overlap (use hasConfirmedOverlap for that)
  * because the queue-join path intentionally targets currently-booked slots.
  */
+/**
+ * True when every UTC calendar day the [startsAt, endsAt] booking spans falls on
+ * a weekday the assigned owner has marked as recurringly available. Returns false
+ * when there are no rules. (Single-timezone; per-building tz is tracked in #72.)
+ */
+async function isCoveredByAvailabilityRules(
+  client: Prisma.TransactionClient,
+  assetId: string,
+  startsAt: Date,
+  endsAt: Date,
+): Promise<boolean> {
+  const rules = await client.assetAvailabilityRule.findMany({ where: { assetId }, select: { weekday: true } })
+  if (rules.length === 0) return false
+  const allowed = new Set(rules.map((r) => r.weekday))
+
+  // Walk each calendar day from the start day up to (but not past) the end instant.
+  const cursor = new Date(Date.UTC(startsAt.getUTCFullYear(), startsAt.getUTCMonth(), startsAt.getUTCDate()))
+  while (cursor <= endsAt) {
+    if (!allowed.has(cursor.getUTCDay())) return false
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return true
+}
+
 export async function assertBookable(
   client: Prisma.TransactionClient,
   user: Pick<User, 'id' | 'globalRole'>,
@@ -119,10 +143,13 @@ export async function assertBookable(
   if (asset.bookingStatus === 'ASSIGNED' && !isSuperAdmin) {
     const isAssignedUser = asset.userAssignments.some((ua) => ua.userId === user.id)
     if (!isAssignedUser) {
+      // A non-assigned user may book if the owner has offered the desk for this
+      // exact time via a one-off window, OR every calendar day the booking spans
+      // falls on a weekday the owner has marked as recurringly available.
       const window = await client.assetAvailabilityWindow.findFirst({
         where: { assetId, startsAt: { lte: startsAt }, endsAt: { gte: endsAt } },
       })
-      if (!window) {
+      if (!window && !(await isCoveredByAvailabilityRules(client, assetId, startsAt, endsAt))) {
         return deny(403, 'ASSET_ASSIGNED', 'This asset is permanently assigned to another user')
       }
     }

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -539,6 +539,48 @@ export async function assetRoutes(fastify: FastifyInstance): Promise<void> {
     return reply.status(200).send({ data: { ok: true } })
   })
 
+  // GET /assets/:id/availability-rules — recurring weekdays this asset is open to others
+  fastify.get('/:id/availability-rules', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const rules = await prisma.assetAvailabilityRule.findMany({
+      where: { assetId: id },
+      select: { weekday: true },
+      orderBy: { weekday: 'asc' },
+    })
+    return reply.status(200).send({ data: { weekdays: rules.map((r) => r.weekday) } })
+  })
+
+  // PUT /assets/:id/availability-rules — replace the recurring-availability weekday set
+  fastify.put('/:id/availability-rules', { preHandler: [requireAuth] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const parsed = z.object({ weekdays: z.array(z.number().int().min(0).max(6)) }).safeParse(request.body)
+    if (!parsed.success) {
+      return reply.status(400).send({ error: { message: 'weekdays must be integers 0–6', code: 'VALIDATION_ERROR' } })
+    }
+    const weekdays = [...new Set(parsed.data.weekdays)]
+
+    // Only the permanently assigned user (or SUPER_ADMIN) may manage rules.
+    const assignment = await prisma.assetUserAssignment.findUnique({
+      where: { assetId_userId: { assetId: id, userId: request.user.id } },
+    })
+    if (!assignment && request.user.globalRole !== GlobalRole.SUPER_ADMIN) {
+      return reply.status(403).send({ error: { message: 'You are not permanently assigned to this asset', code: 'FORBIDDEN' } })
+    }
+
+    const asset = await prisma.asset.findUnique({ where: { id }, select: { id: true } })
+    if (!asset) {
+      return reply.status(404).send({ error: { message: 'Asset not found', code: 'NOT_FOUND' } })
+    }
+
+    await prisma.$transaction([
+      prisma.assetAvailabilityRule.deleteMany({ where: { assetId: id } }),
+      prisma.assetAvailabilityRule.createMany({
+        data: weekdays.map((weekday) => ({ assetId: id, ownerId: request.user.id, weekday })),
+      }),
+    ])
+    return reply.status(200).send({ data: { weekdays: weekdays.sort((a, b) => a - b) } })
+  })
+
   // POST /:id/make-available — assigned user offers their seat to the queue
   fastify.post('/:id/make-available', { preHandler: [requireAuth] }, async (request, reply) => {
     const { id } = request.params as { id: string }

--- a/apps/web/src/components/floor-plan/DeskPanel.tsx
+++ b/apps/web/src/components/floor-plan/DeskPanel.tsx
@@ -16,6 +16,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { useCreateBooking, useJoinQueue, useLeaveQueue, useClaimDesk, useCancelBooking, useMakeAvailable, useQueueEntries } from '@/hooks/useBookings'
 import { formatDateRange } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 import { getDateFormat } from '@/lib/dateFormat'
 import { useAuthStore } from '@/stores/auth'
 import { assetsApi, usersApi, settingsApi, recurringBookingsApi } from '@/lib/api'
@@ -432,6 +433,67 @@ function EditAssetDialog({
   )
 }
 
+// ─── Available-Days Editor (assigned desk owner) ──────────────────────────────
+
+const WEEKDAYS = [
+  { value: 1, label: 'Mon' }, { value: 2, label: 'Tue' }, { value: 3, label: 'Wed' },
+  { value: 4, label: 'Thu' }, { value: 5, label: 'Fri' }, { value: 6, label: 'Sat' }, { value: 0, label: 'Sun' },
+]
+
+function AvailableDaysEditor({ deskId }: { deskId: string }) {
+  const qc = useQueryClient()
+  const { data: weekdays } = useQuery({
+    queryKey: ['assets', deskId, 'availability-rules'],
+    queryFn: () => assetsApi.getAvailabilityRules(deskId),
+    select: (r) => r.data.weekdays,
+  })
+  const save = useMutation({
+    mutationFn: (next: number[]) => assetsApi.setAvailabilityRules(deskId, next),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['assets', deskId, 'availability-rules'] })
+      toast.success('Available days updated')
+    },
+    onError: () => toast.error('Failed to update available days'),
+  })
+
+  const current = new Set(weekdays ?? [])
+  const toggle = (d: number) => {
+    const next = new Set(current)
+    if (next.has(d)) next.delete(d)
+    else next.add(d)
+    save.mutate([...next])
+  }
+
+  return (
+    <div className="pt-2 border-t border-blue-200/70">
+      <p className="text-xs font-medium text-blue-800 mb-1.5">Always available to others on</p>
+      <div className="flex flex-wrap gap-1">
+        {WEEKDAYS.map((w) => {
+          const on = current.has(w.value)
+          return (
+            <button
+              key={w.value}
+              type="button"
+              onClick={() => toggle(w.value)}
+              disabled={save.isPending}
+              aria-pressed={on}
+              className={cn(
+                'rounded-md border px-2 py-1 text-xs font-medium transition-colors',
+                on ? 'border-blue-600 bg-blue-600 text-white' : 'border-blue-200 bg-white text-blue-700 hover:bg-blue-100',
+              )}
+            >
+              {w.label}
+            </button>
+          )
+        })}
+      </div>
+      <p className="mt-1.5 text-[11px] text-blue-600/80">
+        On these weekdays anyone can book your desk — no need to release it each time.
+      </p>
+    </div>
+  )
+}
+
 // ─── Main DeskPanel ───────────────────────────────────────────────────────────
 
 export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onClose, onBookingCreated }: DeskPanelProps) {
@@ -773,6 +835,7 @@ export function DeskPanel({ desk, date, floorId: _floorId, floorZones = [], onCl
                 >
                   {makeAvailable.isPending ? 'Processing…' : 'Make available to queue'}
                 </Button>
+                <AvailableDaysEditor deskId={desk.id} />
               </div>
             )}
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -345,6 +345,11 @@ export const assetsApi = {
     api.post<{ data: AvailabilityWindow }>(`/assets/${id}/availability-windows`, body),
   deleteAvailabilityWindow: (id: string, windowId: string) =>
     api.delete<{ data: { ok: true } }>(`/assets/${id}/availability-windows/${windowId}`),
+  // Recurring weekday availability (assigned desks)
+  getAvailabilityRules: (id: string) =>
+    api.get<{ data: { weekdays: number[] } }>(`/assets/${id}/availability-rules`),
+  setAvailabilityRules: (id: string, weekdays: number[]) =>
+    api.put<{ data: { weekdays: number[] } }>(`/assets/${id}/availability-rules`, { weekdays }),
 }
 
 // --- Bookings ---


### PR DESCRIPTION
Closes #158. Permanently-assigned desk owners can mark the **weekdays their desk is always open to others** (e.g. their work-from-home days), instead of creating a one-off availability window every time.

Builds directly on the existing `AssetAvailabilityWindow` machinery + the ASSIGNED branch of `assertBookable`, per the issue plan.

## Backend
- **Schema:** `AssetAvailabilityRule { assetId, ownerId, weekday }`, unique on `(assetId, weekday)`; cascade-deletes with asset/owner. Migration `20260609130000_assigned_available_days` (applied via `migrate deploy`).
- **Booking gate:** in `assertBookable`, a non-assigned user may book an ASSIGNED desk when the existing one-off window matches **or** every calendar day the booking spans falls on a permitted weekday. Matched at booking time (no window expansion). Single-timezone (UTC day); per-building tz is tracked in #72.
- **API:** `GET /assets/:id/availability-rules` → `{ weekdays }`; `PUT /assets/:id/availability-rules { weekdays:[0–6] }` replaces the set (owner or SUPER_ADMIN only).

## Frontend
- Weekday chip toggles in the assigned-desk panel ("Always available to others on …"), saved on toggle.
- `assetsApi.getAvailabilityRules` / `setAvailabilityRules`.

## Test plan
- [x] `tsc --noEmit` (api + web) — clean
- [x] `eslint` on changed files — clean
- [x] Migration applied to dev DB
- [ ] Manual: as assignee, toggle Fri → another user can book the desk on a Friday but not other days; one-off windows still work

> Note: repo has no API test suite, so this relies on tsc/lint + manual verification.